### PR TITLE
Adding version to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openmc_fusion_benchmarks"
-version = "0.1.0"
 authors = [
   { name="Stefano Segantin", email="segantin@psfc.mit.edu" }
 ]
-
+dynamic = ["version"]
 description = "V&V of openmc for nuclear fusion applications"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -37,3 +36,6 @@ tests = ["pytest>=5.4.3", "pytest-cov", "coveralls"]
 [project.urls]
 "Homepage" = "https://github.com/eepeterson/openmc_fusion_benchmarks"
 "Bug Tracker" = "https://github.com/eepeterson/openmc_fusion_benchmarks/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "openmc_fusion_benchmarks.__version__"} 

--- a/src/openmc_fusion_benchmarks/__init__.py
+++ b/src/openmc_fusion_benchmarks/__init__.py
@@ -6,5 +6,8 @@ from openmc_fusion_benchmarks.utils import *
 from openmc_fusion_benchmarks.benchmark import *
 from openmc_fusion_benchmarks.cloud_interface import *
 
-# new
-from openmc_fusion_benchmarks.statepoint import *
+# this is commented out as the statepoint module is not ready yet and causes
+# the package to break on import. TODO add the statepoint module to the package
+# from openmc_fusion_benchmarks.statepoint import *
+
+__version__ = "0.1.0"

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,7 @@
+import openmc_fusion_benchmarks
+
+
+def test_version():
+    """Simple check that to tst the  .__version__ attribute exists"""
+    version = openmc_fusion_benchmarks.__version__
+    assert isinstance(version, str)


### PR DESCRIPTION
To get the docs working with package versions then we need the package to know what version it is.

This PR adds the __version__ attribute to the package and makes use of it in the pyproject.toml so that we still have a single place where the package is defined. but it is now accessible with the standard ```openmc_fusion_benchmarks.__version__``` attribute