### PR TITLE
moved dependencies to correct place in pyprojects.toml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"  # Change to your required version
+          python-version: "3.12"  # Change to your required version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "numpy",
     "pandas",
     "tables",
-    "importlib",
     "gdown",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,17 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-
-[tool.setuptools.package-data]
-fng_source = ["openmc_fusion_benchmarks/neutron_sources/fng_source/*.csv"]
-
 dependencies = [
-    "openmc",
     "numpy",
     "pandas",
     "tables",
     "importlib",
     "gdown",
-    "json"
 ]
+
+[tool.setuptools.package-data]
+fng_source = ["openmc_fusion_benchmarks/neutron_sources/fng_source/*.csv"]
+
 
 [project.optional-dependencies]
 tests = ["pytest>=5.4.3", "pytest-cov", "coveralls"]

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -3,7 +3,6 @@ import openmc
 from .cloud_interface import download_geometry
 # from openmc_fusion_benchmarks import StatePoint
 # from openmc_fusion_benchmarks import get_statepoint_path
-import importlib
 from functools import wraps
 
 
@@ -20,7 +19,7 @@ class Benchmark:
 
         try:
             module_path = f"openmc_fusion_benchmarks.benchmarks.{self.name}.benchmark_module"
-            benchmark_module = importlib.import_module(module_path)
+            benchmark_module = __import__(module_path, fromlist=['model'])
             # Retrieve the model function or class from the module
             benchmark_func = benchmark_module.model
 


### PR DESCRIPTION
The dependencies entry in the pyprojects.toml file was not in the ```[projects]``` section so it was not actually being used.

this should also fix the ci error (which fails to find gdown package) as now the dependencies will be installed

the ci was getting some packages needed as openmc was bringing them in

also removed json as a dependency as this is in the python standard lib
also removed openmc as a pip dependencies as this is not (yet) available and installed via conda
also removed importlib as a dependency as this is from the python 2.7 days.

@SteSeg can you add a separate PR with a test that covers the use of the ```Benchmark``` class as I would like to be sure this change of importlib to __import__ does not break your code