### PR TITLE
Add `Settings` to the api

### DIFF
--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -199,7 +199,7 @@ class OpenmcBenchmark(Benchmark):
         settings_data = self._benchmark_spec['settings']
 
         settings = openmc.Settings()
-        settings.run_mode = 'fixed source'
+        settings.run_mode = settings_data['run_mode']
         settings.batches = 100
         settings.particles = int(settings_data['particles'] / 100)
         settings.photon_transport = settings_data['photon_transport']

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -202,3 +202,7 @@ class OpenmcBenchmark(Benchmark):
         # source
         # batches
         # particles
+        # photon transport
+        # weight windows
+        # electron treatment
+        # settings.output = {'tallies': False}

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -198,11 +198,17 @@ class OpenmcBenchmark(Benchmark):
     def build_settings(self):
         settings_data = self._benchmark_spec['settings']
 
-        # run mode
-        # source
-        # batches
-        # particles
+        settings = openmc.Settings()
+        settings.run_mode = 'fixed source'
+        settings.batches = 100
+        settings.particles = int(settings_data['particles'] / 100)
+        settings.photon_transport = settings_data['photon_transport']
         # photon transport
         # weight windows
         # electron treatment
-        # settings.output = {'tallies': False}
+        settings.output = {'tallies': False}
+
+        source = self.build_source()
+        settings.source = source
+
+        return settings

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -199,9 +199,12 @@ class OpenmcBenchmark(Benchmark):
         settings_data = self._benchmark_spec['settings']
 
         settings = openmc.Settings()
-        settings.run_mode = settings_data['run_mode']
-        settings.batches = 100
-        settings.particles = int(settings_data['particles'] / 100)
+        if settings_data['run_mode'] == 'fixed source':
+            settings.run_mode = 'fixed source'
+        elif settings_data['run_mode'] == 'k-eigenvalue':
+            settings.run_mode = 'eigenvalue'
+        settings.batches = int(settings_data['batches'])
+        settings.particles = int(settings_data['particles_per_batch'])
         settings.photon_transport = settings_data['photon_transport']
         # photon transport
         # weight windows

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -194,3 +194,11 @@ class OpenmcBenchmark(Benchmark):
             sources.extend(angular_sources)
 
         return source
+
+    def build_settings(self):
+        settings_data = self._benchmark_spec['settings']
+
+        # run mode
+        # source
+        # batches
+        # particles

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -18,6 +18,7 @@ components:
         - materials
         - geometry
         - sources
+        - settings
         - tallies
       properties:
         metadata:
@@ -32,6 +33,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Source'
+        settings:
+          $ref: '#/components/schemas/Settings'
         tallies:
           type: array
           items:
@@ -234,6 +237,21 @@ components:
           units:
             type: string
             enum: [n/s, particles/s]
+
+    Settings:
+      type: object
+      required: [run_mode, batches, particles_per_batch, photon_transport]
+      properties:
+        run_mode:
+          type: string
+          enum: [fixed_source, k_eigenvalue]
+        batches:
+          type: integer
+        particles_per_batch:
+          type: integer
+        photon_transport:
+          type: boolean
+        # Optional entries
 
     Tally:
       type: object

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -127,6 +127,12 @@ sources:
         units:
         description: "Neutron source probability distribution as a function of emission angle and energy"
 
+settings:
+  run_mode: fixed_source
+  batches: 1000000
+  particles_per_batch: 10000000
+  photon_transport: true
+
 tallies:
   - name: neutron_leakage
     description: "Total neutron current leaving the outer surface"

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -129,7 +129,7 @@ sources:
 
 settings:
   run_mode: fixed_source
-  batches: 1000000
+  batches: 100
   particles_per_batch: 10000000
   photon_transport: true
 


### PR DESCRIPTION
This PR implements the `settings` object in the workflow. Settings have been included in `benchmark_schema.yaml`, the `oktavian_al` benchmark `specifications.yaml` and in the `OpenmcBenchmark` class for openmc model generation.

The `Settings` object's `schema` requires at least the `run_mode`, `batches`, `particles_per_batch` and `photon_transport` information in a benchmark's `specifications`.

The `OpenmcBenchmark` class's method `build_settings()` generates an `openmc.Settings` object out of the `specifications`' `settings`.