### PR TITLE
Add `Metadata` to the api

### DIFF
--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -44,6 +44,11 @@ class Benchmark(ABC):
         """Build tallies for the benchmark."""
         pass
 
+    @abstractmethod
+    def metadata(self):
+        """Get metadata for the benchmark."""
+        pass
+
 
 class OpenmcBenchmark(Benchmark):
     def __init__(self, name: str):
@@ -194,3 +199,47 @@ class OpenmcBenchmark(Benchmark):
             sources.extend(angular_sources)
 
         return source
+
+    @property
+    def metadata(self):
+        metadata = self._benchmark_spec['metadata']
+
+        lines = []
+        lines.append(f"📘 Title: {metadata.get('title', 'N/A')}")
+        lines.append("")
+        lines.append(f"🔖 Type: {metadata.get('type', 'N/A')}")
+        lines.append("")
+        lines.append(f"📂 Category: {metadata.get('category', 'N/A')}")
+        lines.append("")
+        lines.append(f"🧮 Version: {metadata.get('version', 'N/A')}")
+        lines.append("")
+        lines.append(f"📝 Description: {metadata.get('description', 'N/A')}")
+        lines.append(f"📅 Date: {metadata.get('date', 'N/A')}")
+
+        location = metadata.get("location", {})
+        lines.append("📍 Location:")
+        lines.append(f"   - Facility: {location.get('facility', 'N/A')}")
+        lines.append(f"   - City: {location.get('city', 'N/A')}")
+        lines.append(f"   - Country: {location.get('country', 'N/A')}")
+        lines.append("")
+
+        references = metadata.get("references", [])
+        lines.append("🔗 References:")
+        for ref in references:
+            lines.append(f"   - Title: {ref.get('title', 'N/A')}")
+            if 'doi' in ref:
+                lines.append(f"     DOI: {ref['doi']}")
+            if 'url' in ref:
+                lines.append(f"     URL: {ref['url']}")
+
+        authors = metadata.get("authors", [])
+        if authors:
+            lines.append("")
+            lines.append("👥 Authors:")
+            for author in authors:
+                name = author.get("name", "N/A")
+                affiliation = author.get("affiliation", "N/A")
+                email = author.get("email", "N/A")
+                lines.append(f"   - {name} ({affiliation}, {email})")
+
+        print("\n".join(lines))

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -44,14 +44,48 @@ components:
 
     Metadata:
       type: object
-      required: [title, version, description, experiment_type, experiment_category, references]
+      required: [title, type, category, version, description, date, location, references]
       properties:
         title:
           type: string
+        type:
+          type: string
+          enum: [experimental, computational, analytic]
+        category:
+          type: string
+          enum: [fusion, fission, accelerator, other]
         version:
           type: string
+          pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"  # Major.Minor.Patch format
         description:
           type: string
+        date:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"  # YYYY-MM-DD format
+        location:
+          type: object
+          properties:
+            facility:
+              type: string
+            city:
+              type: string
+            country:
+              type: string
+          required: [facility, city, country]
+        references:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              doi:
+                type: string
+                format: uri  # Ensures a valid URL format for DOI
+            required: [title]
+            anyOf:
+            - required: [doi]
+            - required: [url]
         authors:
           type: array
           items:
@@ -64,42 +98,6 @@ components:
               email:
                 type: string
             required: [name, affiliation, email]
-        experiment_date:
-          type: string
-          pattern: "^\\d{4}-\\d{2}-\\d{2}$"  # YYYY-MM-DD format
-        date_created:
-          type: string
-          pattern: "^(N/A|\\d{4}-\\d{2}-\\d{2})$"  # Allows "N/A" or date format
-        last_updated:
-          type: string
-          pattern: "^(N/A|\\d{4}-\\d{2}-\\d{2})$"  # Allows "N/A" or date format
-        location:
-          type: object
-          properties:
-            facility:
-              type: string
-            city:
-              type: string
-            country:
-              type: string
-          required: [facility, city, country]
-        experiment_type:
-          type: string
-          enum: [fusion, fission, accelerator, other]
-        experiment_category:
-          type: string
-          enum: [neutron, gamma, mixed]
-        references:
-          type: array
-          items:
-            type: object
-            properties:
-              title:
-                type: string
-              doi:
-                type: string
-                format: uri  # Ensures a valid URL format for DOI
-            required: [title, doi]
 
     Material:
       type: object

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -14,8 +14,12 @@ metadata:
     city: Osaka
     country: Japan
   references:
-    - doi: "https://doi.org/10.1016/j.anucene.2021.108254"
-    - doi: "https://doi.org/10.1016/j.anucene.2009.12.016"
+    - title: "Compilation of benchmark results for fusion related Nuclear Data"
+      url: "https://inis.iaea.org/records/01rr2-t5f29"
+    - title: "SINBAD–Radiation shielding benchmark experiments."
+      doi: "https://doi.org/10.1016/j.anucene.2021.108254"
+    - title: "The OKTAVIAN TOF Experiments in SINBAD: Evaluation of the Experimental Uncertainties"
+      doi: "https://doi.org/10.1016/j.anucene.2009.12.016"
 
 materials:
   - id: 1

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -8,11 +8,7 @@ metadata:
     is an intermediate quality neutronics experiment conducted to measure the leakage 
     neutron spectrum from the outer surface of a aluminium sphere with a radius of 20 cm, 
     surrounded by a 0.2 cm thick stainless steel shield, using 14 MeV neutrons.
-  authors:
-    - name: N/A
-      affiliation: N/A
-      email: N/A
-  experiment_date: "1988-12-22"
+  date: "1988-12-22"
   location:
     facility: OKTAVIAN
     city: Osaka

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: OKTAVIAN AL Benchmark
+  type: experimental
+  category: fusion
   version: 1.0.0
   description: >
     The Osaka Aluminium Sphere Benchmark Experiment (OKTAVIAN) (December 22, 1988) 
@@ -11,17 +13,13 @@ metadata:
       affiliation: N/A
       email: N/A
   experiment_date: "1988-12-22"
-  date_created: N/A
-  last_updated: N/A
   location:
     facility: OKTAVIAN
     city: Osaka
     country: Japan
-  experiment_type: fusion
-  experiment_category: neutron
   references:
-    - title: "SINBAD–Radiation shielding benchmark experiments."
-      doi: "https://doi.org/10.1016/j.anucene.2021.108254"
+    - doi: "https://doi.org/10.1016/j.anucene.2021.108254"
+    - doi: "https://doi.org/10.1016/j.anucene.2009.12.016"
 
 materials:
   - id: 1


### PR DESCRIPTION
This PR adds metadata in the `benchmark_schema.yaml`, `oktavian_al specifications.yaml` files and the corresponding python api in `benchmark.py` (`Benchmark` and `OpenmcBenchmark` classes). This:

```python
import openmc_fusion_benchmarks as ofb
ok = ofb.Openmcbenchmark(name="oktavian_al")
ok.metadata
```

prints this:

![image](https://github.com/user-attachments/assets/df1c2f00-8151-4db7-9428-0c27e0bb20c7)

The `Metadata` object's `schema` requires at least the `title`, `type`, `category`, `version`, `description`, `date`, `location` and  `references` objects in a benchmark's `specification`.
