### PR TITLE
Add `Tallies` to the api

### DIFF
--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -194,3 +194,6 @@ class OpenmcBenchmark(Benchmark):
             sources.extend(angular_sources)
 
         return source
+
+    def build_tallies(self):
+        tallies_data = self._benchmark_spec['tallies']

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -197,3 +197,37 @@ class OpenmcBenchmark(Benchmark):
 
     def build_tallies(self):
         tallies_data = self._benchmark_spec['tallies']
+
+        # Initialize openmc tallies
+        tallies = openmc.Tallies()
+
+        for t in tallies_data:
+            tally = openmc.Tally(name=t['name'])
+            # Handle particle type
+            particle = t['particle_type']
+            particle_filter = openmc.ParticleFilter([particle])
+            tally.filters.append(particle_filter)
+            # Handle domains/filters
+            for d in t['domains']:
+                if d['type'] == 'cell':
+                    filter = openmc.CellFilter(d['values'])
+                elif d['type'] == 'material':
+                    filter = openmc.MaterialFilter(d['values'])
+                elif d['type'] == 'surface':
+                    filter = openmc.SurfaceFilter(d['values'])
+                elif d['type'] == 'energy':
+                    filter = openmc.EnergyFilter(d['values'])
+                else:
+                    raise ValueError(
+                        f"Unsupported domain type: {d['type']}")
+
+                tally.filters.append(filter)
+
+            # Handle quantities/scores
+            for q in t['quantities']:
+                tally.scores.append(q)
+
+            # Store in tallies
+            tallies.append(tally)
+
+        return tallies

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -237,38 +237,32 @@ components:
 
     Tally:
       type: object
+      required: [name, particle, domains, quantities]
       properties:
-        name:
+        name: 
           type: string
-        description:
+        description: 
           type: string
         particle:
           type: string
-          enum: [neutron, photon]  # Enforcing valid particle types
-        quantity:
-          type: string
-        domain:
-          type: object
-          properties:
-            type:
-              type: string
-              enum: [surface, volume]  # Adjust if needed
-            id:
-              type: integer
-          required: [type, id]
-        values:
+          enum: [neutron, photon, electron, positron]
+        domains:
           type: array
           items:
             type: object
+            required: [type, values]
             properties:
-              value:
+              type:
+                type: string
+                enum: [surface, cell, material, energy, mesh]
+              values:
                 type: array
-                items:
-                  type: number
               units:
                 type: string
-            required: [value, units]
-      required: [name, description, particle, quantity, domain, values]
+        quantities:
+          type: array
+          items:
+            type: string
 
     IrradiationSchedule:
       type: object

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -237,13 +237,13 @@ components:
 
     Tally:
       type: object
-      required: [name, particle, domains, quantities]
+      required: [name, particle_type, domains, quantities]
       properties:
         name: 
           type: string
         description: 
           type: string
-        particle:
+        particle_type:
           type: string
           enum: [neutron, photon, electron, positron]
         domains:

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -131,12 +131,12 @@ tallies:
   - name: neutron_leakage
     description: "Total neutron current leaving the outer surface"
     particle: neutron
-    quantity: current
-    domain:
-      type: surface
-      id: 6
-    values:
-      - value: [97122., 101090., 105210., 109500., 113970., 118620.,
+    quantities: [current]
+    domains:
+      - type: surface
+        values: [6]
+      - type: energy
+        values: [97122., 101090., 105210., 109500., 113970., 118620.,
                 123470., 128500., 133750., 139210., 144890., 150800.,
                 156960., 163360., 170030., 176970., 184190., 191710.,
                 199530., 207670., 216150., 224970., 234150., 243710.,
@@ -160,15 +160,16 @@ tallies:
                 15002000., 15615000., 16252000., 16915000., 17605000., 18324000.,
                 19072000., 19850000., 20660000.]
         units: particle/src/cm**2
+
   - name: photon_leakage
     description: "Total photon current leaving the outer surface"
     particle: photon
-    quantity: current
-    domain:
-      type: surface
-      id: 6
-    values:
-      - value: [500000.,   600000.,   700000.,   800000.,   900000.,  1000000.,
+    quantities: [current]
+    domains:
+      - type: surface
+        values: [6]
+      - type: energy
+        values: [500000.,   600000.,   700000.,   800000.,   900000.,  1000000.,
                 1100000.,  1200000.,  1300000.,  1400000.,  1500000.,  1600000.,
                 1700000.,  1800000.,  1900000.,  2000000.,  2100000.,  2200000.,
                 2300000.,  2400000.,  2500000.,  2600000.,  2700000.,  2800000.,

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -130,7 +130,7 @@ sources:
 tallies:
   - name: neutron_leakage
     description: "Total neutron current leaving the outer surface"
-    particle: neutron
+    particle_type: neutron
     quantities: [current]
     domains:
       - type: surface
@@ -163,7 +163,7 @@ tallies:
 
   - name: photon_leakage
     description: "Total photon current leaving the outer surface"
-    particle: photon
+    particle_type: photon
     quantities: [current]
     domains:
       - type: surface


### PR DESCRIPTION
This PR defines the `Tallies` and `Tally` objects in the `benchmark_schema.yaml` file and implements it in the `oktavian_al` benchmark `specifications.yaml` file. 

It also implements in the `OpenmcBenchmark` class the `build_tallies()` method, which automatically builds builds an `Openmc.Tallies` object from a benchmark `specifications.yaml` file. E.g.:

```python
import openmc_fusion_benchmark as ofb

ok = ofb.OpenmcBenchmark(name='oktavian_al')
ok.build_tallies()
```

gives:

![image](https://github.com/user-attachments/assets/ec70c441-b2f8-43c1-85fb-9ecadd954340)


The `Tally` object's `schema` requires at least the `name`, `particle_type`, `domains` and `quantities` objects to be defined in each benchmark `specifications`.
- `particle_type` and every `domains` object get converted in `openmc.Filter` objects
- `quantities` get converted in `openmc.Tally.score`

