### PR TITLE
convention changes: private methods, metadata visualization and object names

### DIFF
--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -114,7 +114,7 @@ class OpenmcBenchmark(Benchmark):
         # More than one source is possible
         for source in source_data:
             # Handle source particle type
-            particle = source['particle_type']
+            particle = source['particle']
 
             # Handle source spatial distribution
             if source['spatial_distribution']['type'] == 'point':
@@ -209,7 +209,7 @@ class OpenmcBenchmark(Benchmark):
         for t in tallies_data:
             tally = openmc.Tally(name=t['name'])
             # Handle particle type
-            particle = t['particle_type']
+            particle = t['particle']
             particle_filter = openmc.ParticleFilter([particle])
             tally.filters.append(particle_filter)
             # Handle filters

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -94,17 +94,7 @@ class Benchmark(ABC):
     def metadata(self):
         """Show metadata for the benchmark."""
 
-        class _MetadataDisplay:
-            def __init__(self, text):
-                self.text = text
-
-            def __str__(self):
-                return self.text
-
-            def __repr__(self):
-                return self.text
-
-        return _MetadataDisplay(self._metadata)
+        return self._metadata
 
 
 class OpenmcBenchmark(Benchmark):

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -13,21 +13,23 @@ class Benchmark(ABC):
     def __init__(self, name: str):
         self.name = name
 
-        # Validate the benchmark specification
-        validate_benchmark(name)
+        # # Validate the benchmark specification
+        # validate_benchmark(name)
 
         with (BENCHMARK_DIR / f"{self.name}/specifications.yaml").open("r") as f:
             self._benchmark_spec = yaml.safe_load(f)
+
+        self._read_metadata()
 
     @abstractmethod
     def build_materials(self):
         """Build materials for the benchmark."""
         pass
 
-    @abstractmethod
-    def build_geometry(self):
-        """Build geometry for the benchmark."""
-        pass
+    # @abstractmethod
+    # def build_geometry(self):
+    #     """Build geometry for the benchmark."""
+    #     pass
 
     @abstractmethod
     def build_source(self):
@@ -44,10 +46,65 @@ class Benchmark(ABC):
         """Build tallies for the benchmark."""
         pass
 
-    @abstractmethod
+    def _read_metadata(self):
+        """Read metadata from the benchmark specification."""
+        metadata = self._benchmark_spec['metadata']
+
+        lines = []
+        lines.append(f"📘 Title: {metadata.get('title', 'N/A')}")
+        lines.append("")
+        lines.append(f"🔖 Type: {metadata.get('type', 'N/A')}")
+        lines.append("")
+        lines.append(f"📂 Category: {metadata.get('category', 'N/A')}")
+        lines.append("")
+        lines.append(f"🧮 Version: {metadata.get('version', 'N/A')}")
+        lines.append("")
+        lines.append(f"📝 Description: {metadata.get('description', 'N/A')}")
+        lines.append(f"📅 Date: {metadata.get('date', 'N/A')}")
+
+        location = metadata.get("location", {})
+        lines.append("📍 Location:")
+        lines.append(f"   - Facility: {location.get('facility', 'N/A')}")
+        lines.append(f"   - City: {location.get('city', 'N/A')}")
+        lines.append(f"   - Country: {location.get('country', 'N/A')}")
+        lines.append("")
+
+        references = metadata.get("references", [])
+        lines.append("🔗 References:")
+        for ref in references:
+            lines.append(f"   - Title: {ref.get('title', 'N/A')}")
+            if 'doi' in ref:
+                lines.append(f"     DOI: {ref['doi']}")
+            if 'url' in ref:
+                lines.append(f"     URL: {ref['url']}")
+
+        authors = metadata.get("authors", [])
+        if authors:
+            lines.append("")
+            lines.append("👥 Authors:")
+            for author in authors:
+                name = author.get("name", "N/A")
+                affiliation = author.get("affiliation", "N/A")
+                email = author.get("email", "N/A")
+                lines.append(f"   - {name} ({affiliation}, {email})")
+
+        self._metadata = "\n".join(lines)
+
+    @property
     def metadata(self):
-        """Get metadata for the benchmark."""
-        pass
+        """Show metadata for the benchmark."""
+
+        class _MetadataDisplay:
+            def __init__(self, text):
+                self.text = text
+
+            def __str__(self):
+                return self.text
+
+            def __repr__(self):
+                return self.text
+
+        return _MetadataDisplay(self._metadata)
 
 
 class OpenmcBenchmark(Benchmark):
@@ -236,50 +293,6 @@ class OpenmcBenchmark(Benchmark):
             tallies.append(tally)
 
         return tallies
-
-    @property
-    def metadata(self):
-        metadata = self._benchmark_spec['metadata']
-
-        lines = []
-        lines.append(f"📘 Title: {metadata.get('title', 'N/A')}")
-        lines.append("")
-        lines.append(f"🔖 Type: {metadata.get('type', 'N/A')}")
-        lines.append("")
-        lines.append(f"📂 Category: {metadata.get('category', 'N/A')}")
-        lines.append("")
-        lines.append(f"🧮 Version: {metadata.get('version', 'N/A')}")
-        lines.append("")
-        lines.append(f"📝 Description: {metadata.get('description', 'N/A')}")
-        lines.append(f"📅 Date: {metadata.get('date', 'N/A')}")
-
-        location = metadata.get("location", {})
-        lines.append("📍 Location:")
-        lines.append(f"   - Facility: {location.get('facility', 'N/A')}")
-        lines.append(f"   - City: {location.get('city', 'N/A')}")
-        lines.append(f"   - Country: {location.get('country', 'N/A')}")
-        lines.append("")
-
-        references = metadata.get("references", [])
-        lines.append("🔗 References:")
-        for ref in references:
-            lines.append(f"   - Title: {ref.get('title', 'N/A')}")
-            if 'doi' in ref:
-                lines.append(f"     DOI: {ref['doi']}")
-            if 'url' in ref:
-                lines.append(f"     URL: {ref['url']}")
-
-        authors = metadata.get("authors", [])
-        if authors:
-            lines.append("")
-            lines.append("👥 Authors:")
-            for author in authors:
-                name = author.get("name", "N/A")
-                affiliation = author.get("affiliation", "N/A")
-                email = author.get("email", "N/A")
-                lines.append(f"   - {name} ({affiliation}, {email})")
-
-        print("\n".join(lines))
 
     def build_settings(self):
         settings_data = self._benchmark_spec['settings']

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -212,8 +212,8 @@ class OpenmcBenchmark(Benchmark):
             particle = t['particle_type']
             particle_filter = openmc.ParticleFilter([particle])
             tally.filters.append(particle_filter)
-            # Handle domains/filters
-            for d in t['domains']:
+            # Handle filters
+            for d in t['filters']:
                 if d['type'] == 'cell':
                     filter = openmc.CellFilter(d['values'])
                 elif d['type'] == 'material':

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -228,8 +228,8 @@ class OpenmcBenchmark(Benchmark):
 
                 tally.filters.append(filter)
 
-            # Handle quantities/scores
-            for q in t['quantities']:
+            # Handle scores
+            for q in t['scores']:
                 tally.scores.append(q)
 
             # Store in tallies

--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -26,10 +26,10 @@ class Benchmark(ABC):
         """Build materials for the benchmark."""
         pass
 
-    # @abstractmethod
-    # def build_geometry(self):
-    #     """Build geometry for the benchmark."""
-    #     pass
+    @abstractmethod
+    def build_geometry(self):
+        """Build geometry for the benchmark."""
+        pass
 
     @abstractmethod
     def build_source(self):
@@ -131,6 +131,11 @@ class OpenmcBenchmark(Benchmark):
             materials.append(mat)
 
         return materials
+
+    def build_geometry(self):
+        raise NotImplementedError(
+            'Geometry building not implemented yet. Please implement the build_geometry method in the OpenmcBenchmark class.'
+        )
 
     def build_source(self):
         source_data = self._benchmark_spec['sources']

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -152,9 +152,9 @@ components:
     
     Source:
       type: object
-      required: [particle_type, spatial_distribution, angular_energy_distribution, strength]
+      required: [particle, spatial_distribution, angular_energy_distribution, strength]
       properties:
-        particle_type:
+        particle:
           type: string
           enum: [neutron, photon]
         strength:
@@ -253,13 +253,13 @@ components:
 
     Tally:
       type: object
-      required: [name, particle_type, filters, scores]
+      required: [name, particle, filters, scores]
       properties:
         name: 
           type: string
         description: 
           type: string
-        particle_type:
+        particle:
           type: string
           enum: [neutron, photon, electron, positron]
         filters:

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -253,7 +253,7 @@ components:
 
     Tally:
       type: object
-      required: [name, particle_type, domains, quantities]
+      required: [name, particle_type, filters, quantities]
       properties:
         name: 
           type: string
@@ -262,7 +262,7 @@ components:
         particle_type:
           type: string
           enum: [neutron, photon, electron, positron]
-        domains:
+        filters:
           type: array
           items:
             type: object

--- a/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/benchmark_schema.yaml
@@ -253,7 +253,7 @@ components:
 
     Tally:
       type: object
-      required: [name, particle_type, filters, quantities]
+      required: [name, particle_type, filters, scores]
       properties:
         name: 
           type: string
@@ -275,7 +275,7 @@ components:
                 type: array
               units:
                 type: string
-        quantities:
+        scores:
           type: array
           items:
             type: string

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -135,7 +135,7 @@ tallies:
   - name: neutron_leakage
     description: "Total neutron current leaving the outer surface"
     particle_type: neutron
-    quantities: [current]
+    scores: [current]
     filters:
       - type: surface
         values: [6]
@@ -168,7 +168,7 @@ tallies:
   - name: photon_leakage
     description: "Total photon current leaving the outer surface"
     particle_type: photon
-    quantities: [current]
+    scores: [current]
     filters:
       - type: surface
         values: [6]

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -80,7 +80,7 @@ geometry:
         material_id: 2
 
 sources:
-  - particle_type: neutron
+  - particle: neutron
     strength: 1.0
     spatial_distribution:
       type: point
@@ -134,7 +134,7 @@ settings:
 tallies:
   - name: neutron_leakage
     description: "Total neutron current leaving the outer surface"
-    particle_type: neutron
+    particle: neutron
     scores: [current]
     filters:
       - type: surface
@@ -167,7 +167,7 @@ tallies:
 
   - name: photon_leakage
     description: "Total photon current leaving the outer surface"
-    particle_type: photon
+    particle: photon
     scores: [current]
     filters:
       - type: surface

--- a/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
+++ b/src/openmc_fusion_benchmarks/benchmarks/oktavian_al/specifications.yaml
@@ -136,7 +136,7 @@ tallies:
     description: "Total neutron current leaving the outer surface"
     particle_type: neutron
     quantities: [current]
-    domains:
+    filters:
       - type: surface
         values: [6]
       - type: energy
@@ -169,7 +169,7 @@ tallies:
     description: "Total photon current leaving the outer surface"
     particle_type: photon
     quantities: [current]
-    domains:
+    filters:
       - type: surface
         values: [6]
       - type: energy


### PR DESCRIPTION
Here some changes in the convention of some parts of the code:

 of the schema and impacted files (i.e. `benchmark_schema.yaml`, `specifications.yaml` and `OpenmcBenchmark` class in `benchmark.py`).

name changes
- `domains` -> `filters` in Tally objects
- `quantities` -> `scores` in Tally objects
- `particle_type` -> `particle` in Tally and Source objects

The visualization of the `Metadata` object has been changed:
The code to parse metadata has been moved directly in the base class `Benchmark`. More specifically in the `_read_metadata()` private metod. the `@property` `metadata(self)` visualizes the metadata. Such property contains a `_MetadataDisplay`  nested class that helps with the correct processing and visualization of metadata lines and newlines. So:

```python
import openmc_fusion_benchmarks as ofb

ok = ofb.OpenmcBenchmark(name='oktavian_al')
ok.metadata
```
Shows on terminal and notebooks something like:

![image](https://github.com/user-attachments/assets/0518dd00-d3c5-49c5-90d9-02ca07a41a71)


Also, commented out the `abstractmethod` `build_geometry()` in `Benchmark` as it is still not there in any subclass. And commented out automatic validation of benchmark specs against schema during benchmark instantiation.