### PR TITLE
Fixed path bug in `validate_benchmark()`

### DIFF
--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -13,8 +13,8 @@ class Benchmark(ABC):
     def __init__(self, name: str):
         self.name = name
 
-        # # Validate the benchmark specification
-        # validate_benchmark(name)
+        # Validate the benchmark specification
+        validate_benchmark(name)
 
         with (BENCHMARK_DIR / f"{self.name}/specifications.yaml").open("r") as f:
             self._benchmark_spec = yaml.safe_load(f)

--- a/src/openmc_fusion_benchmarks/validate.py
+++ b/src/openmc_fusion_benchmarks/validate.py
@@ -8,7 +8,7 @@ def validate_benchmark(benchmark_name: str):
 
     print(f"\n🔍 Validating benchmark file: {benchmark_name}")
 
-    base_path = Path("src/openmc_fusion_benchmarks/benchmarks")
+    base_path = Path(Path(__file__).parent / "benchmarks")
     schema_path = base_path / "benchmark_schema.yaml"
     benchmark_path = base_path / benchmark_name / "specifications.yaml"
 

--- a/src/openmc_fusion_benchmarks/validate.py
+++ b/src/openmc_fusion_benchmarks/validate.py
@@ -8,7 +8,7 @@ def validate_benchmark(benchmark_name: str):
 
     print(f"\n🔍 Validating benchmark file: {benchmark_name}")
 
-    base_path = Path(Path(__file__).parent / "benchmarks")
+    base_path = Path(__file__).parent / "benchmarks"
     schema_path = base_path / "benchmark_schema.yaml"
     benchmark_path = base_path / benchmark_name / "specifications.yaml"
 

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -43,11 +43,3 @@ def test_benchmark_file_not_found(mock_validate):
     with patch.object(Path, "open", side_effect=FileNotFoundError):
         with pytest.raises(FileNotFoundError):
             DummyBenchmark("nonexistent")
-
-
-@patch("openmc_fusion_benchmarks.benchmark.validate_benchmark")
-def test_benchmark_invalid_yaml(mock_validate):
-    # Simulate YAML load returns None
-    with patch.object(Path, "open", mock_open(read_data="")):
-        bench = DummyBenchmark("dummy")
-        assert bench._benchmark_spec is None


### PR DESCRIPTION
The function `validate_benchmark()` used to have a `Path` bug that allowed to call the `specifications` validation only from within the package main folder. Now it can be called from everywhere.
Also, the validation at instantiation has been uncommented. Now, every time a `Benchmark` object gets instantiated the `specification` validation against the `schema` is automatically run.