### PR TITLE
testing building of docs on each pr and selective publish

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,12 @@
 name: deploy-book
 
-# Run this when the develop branch changes
+# Run this when the develop branch changes on on a pull request
 on:
   push:
     branches:
     - develop
+  pull_request:
+
 
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
@@ -38,7 +40,8 @@ jobs:
       with:
         path: "docs/_build/html"
 
-    # Deploy the book's HTML to GitHub Pages
+    # Deploy the book's HTML to GitHub Pages if the action was triggered by a push to develop
     - name: Deploy to GitHub Pages
       id: deployment
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR changes the jupyter book building action so that it also runs on each PR as well as a push to develop

The pushing to gh-pages is restricted to when the action is triggered by a push to develop

I think in the settings-pages there is a permissions setting to change that allows the action to push to gh-pages