### PR TITLE
Update to keep up with `cad-to-dagmc'

### DIFF
--- a/src/openmc_fusion_benchmarks/benchmark.py
+++ b/src/openmc_fusion_benchmarks/benchmark.py
@@ -137,7 +137,7 @@ class OpenmcBenchmark(Benchmark):
 
     def build_geometry(self):
 
-        def build_mesh(cad_file: str, material_tags, set_size: dict, global_mesh_size_min: float, global_mesh_size_max: float, dimensions: int = 2, mesh_file: str = "mesh.h5m"):
+        def build_mesh(cad_file: str, material_tags, set_size: dict, global_mesh_size_min: float, global_mesh_size_max: float, mesh_file: str = "mesh.h5m"):
 
             # Instantiate the CadToDagmc model
             model = CadToDagmc()
@@ -147,7 +147,7 @@ class OpenmcBenchmark(Benchmark):
 
             # Generate the mesh
             model.export_dagmc_h5m_file(imprint=True, min_mesh_size=global_mesh_size_min,
-                                        max_mesh_size=global_mesh_size_max, set_size=set_size, dimensions=dimensions, filename=mesh_file)
+                                        max_mesh_size=global_mesh_size_max, set_size=set_size, filename=mesh_file)
 
         # Implement the logic to build geometry for OpenMC
         geometry_data = self._benchmark_spec['geometry']


### PR DESCRIPTION
Removed `dimension` argument in meshing function of `OpenmcBenchmark.build_geometry()` method to keep up with [cad-to-dagmc](https://github.com/fusion-energy/cad_to_dagmc) package recent updates.