### PR TITLE
Point to correct branch of `lfs` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lfs"]
 	path = lfs
 	url = https://github.com/SteSeg/openmc_fusion_benchmarks-lfs.git
+	branch = main


### PR DESCRIPTION
Just specified to point to the correct branch of the `openmc_fusion_benchmark-lfs` submodule.