### PR TITLE
adding link to jupyter book on gh pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
 [![CI testing](https://github.com/SteSeg/openmc_fusion_benchmarks/actions/workflows/ci.yml/badge.svg?branch=add_ci)](https://github.com/SteSeg/openmc_fusion_benchmarks/workflows/ci.yml)
 [![Code Coverage](https://coveralls.io/repos/github/SteSeg/openmc_fusion_benchmarks/badge.svg?branch=add_ci)](https://coveralls.io/github/SteSeg/openmc_fusion_benchmarks?branch=add_ci)
+[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://eepeterson.github.io/openmc_fusion_benchmarks)
+
+
 
 # openmc_fusion_benchmarks
 OpenMC Fusion Benchmarks is a platform for V&V of fusion neutronics. It focuses on fusion-relevant integral benchmarks. It relies on an automated workflow for model simulation, data postprocessing, visualization and analysis. It embeds a database of experimental and numerical results for quick comparisons to which users can contribute to. The database contribution workflow is fully automated.


### PR DESCRIPTION
I noticed some read the docs activity on the repo and I just wanted to check that people know there is already a github pages of the repo. Is the plan to move everything to read the docs?

If you want to stick with gh pages then might be worth adding a small link for the currently hosted jupyter book which can be found here 


https://eepeterson.github.io/openmc_fusion_benchmarks