### PR TITLE
New TMC modes: `sequential`, `matrix` and `diagonal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install -c conda-forge openmc>=0.14.0 moab
+
+      - name: Create Conda environment
+        shell: bash -l {0}
+        run: |
+          mamba install -c conda-forge openmc>=0.14.0 moab
+          echo "Installation complete. Installed packages:"
+          mamba list | grep -E "moab|pymoab|openmc"
+          python -c "import pymoab; print('✓ pymoab imported successfully')" || echo "✗ pymoab import failed"
   
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,35 +19,25 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"  # Change to your required version
+          python-version: "3.12"
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test-env
           miniforge-version: latest
-          use-mamba: true
           channels: conda-forge
 
-      - name: Create Conda environment
+      - name: Install OpenMC via Conda
         shell: bash -l {0}
         run: |
           mamba install -c conda-forge openmc>=0.14.0
 
-      - name: Install pymoab
-        shell: bash
-        run: |
-          python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
-          python -c "import pymoab"
-          python -m pip install git+https://github.com/svalinn/pydagmc
-
-      - name: Verify MOAB installation
+      - name: Install pymoab and pydagmc
         shell: bash -l {0}
         run: |
-          mamba install -c conda-forge openmc>=0.14.0 moab
-          echo "Installation complete. Installed packages:"
-          mamba list | grep -E "moab|pymoab|openmc"
-          python -c "import pymoab; print('✓ pymoab imported successfully')" || echo "✗ pymoab import failed"
+          python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
+          python -m pip install git+https://github.com/svalinn/pydagmc
   
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,16 @@ jobs:
       - name: Create Conda environment
         shell: bash -l {0}
         run: |
-          mamba install -c conda-forge openmc>=0.14.0 moab
+          mamba install -c conda-forge openmc>=0.14.0
 
-      - name: Create Conda environment
+      - name: Install pymoab
+        shell: bash
+        run: |
+          python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
+          python -c "import pymoab"
+          python -m pip install git+https://github.com/svalinn/pydagmc
+
+      - name: Verify MOAB installation
         shell: bash -l {0}
         run: |
           mamba install -c conda-forge openmc>=0.14.0 moab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
         shell: bash -l {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: coveralls
+        run: coveralls || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
         with:
           activate-environment: test-env
           miniforge-version: latest
-          # use-mamba: true
+          use-mamba: true
           channels: conda-forge
 
       - name: Create Conda environment
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge openmc>=0.14.0
+          mamba install -c conda-forge openmc>=0.14.0 moab
   
       - name: Install dependencies
         shell: bash -l {0}

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -19,28 +19,16 @@ class TMCManager:
 
         if rng is None:
             if seed is None:
-                seed = 123456  # or from config
+                seed = 123456
             self.master_rng = np.random.default_rng(seed)
         else:
             self.master_rng = rng
-        
-        if rng is not None:
-            self.rng = rng
-        else:
-            self.rng = np.random.default_rng(seed)
 
         self.base_model = base_model
         self.realizations = realizations
-        
-        # perturbations is a list of factories: factory(rng) -> perturb(model)
-        # call each factory once to get a closure perturb(model) -> model
-        perts = []
-        for factory in perturbations:
-            base_seed = int(self.master_rng.integers(0, 2**31))
-            perturb = factory(base_seed)
-            perts.append(perturb)
-        
-        self.perturbations = perts
+
+       # Wrap user perturbations into indexed perturb(model, idx)
+        self.perturbations = self._build_indexed_perturbations(perturbations)
 
     def run(self, cwd='.', *args, **kwargs):
 
@@ -61,11 +49,6 @@ class TMCManager:
                 perturbed_model = copy.deepcopy(self.base_model)
 
                 # Apply each perturbation with its corresponding realization index
-
-                # Might need idx as argument for reproducibility, i.e.:
-                # for perturb, ridx in zip(self.perturbations, idx_tuple):
-                #     perturbed_model = perturb(perturbed_model, ridx, self.rng)
-
                 for pert, ridx in zip(self.perturbations, idx_tuple):
                     perturbed_model = pert(perturbed_model, ridx)
 
@@ -75,21 +58,44 @@ class TMCManager:
                     run_dir.mkdir(parents=True, exist_ok=True)
 
                     # Run model
-                    # sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
-
-                    print(s)  # delete later
-                    sp_path = run_dir / "model.xml"  # delete later
-                    perturbed_model.export_to_model_xml(str(sp_path))  # delete later
-
+                    sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
                     sp_path = Path(sp_path).resolve()
 
                     # Store statepoint path in manifest
                     rec = {
-                            "combo_index": s,
                             "indices": list(idx_tuple),  # [i0, i1, ..., i_{p-1}]
                             "statepoint": str(sp_path.relative_to(cwd)),
                         }
                     f_manifest.write(json.dumps(rec) + "\n")
+                    f_manifest.flush()
+
+    def _build_indexed_perturbations(self, user_factories):
+        """
+        user_factories: list of callables, each like:
+            factory() -> inner(model, rng)
+
+        Returns list of callables:
+            perturb(model, idx) -> model
+        """
+        indexed = []
+        for factory in user_factories:
+            # 1) get user's inner function: (model, rng) -> model
+            inner = factory()
+
+            # 2) draw a unique base_seed for this perturbation
+            base_seed = int(self.master_rng.integers(0, 2**31))
+
+            # 3) wrap inner into perturb(model, idx)
+            def make_wrapper(inner_func, base_seed):
+                def perturb(model, idx):
+                    local_seed = base_seed + idx
+                    local_rng = np.random.default_rng(local_seed)
+                    return inner_func(model, local_rng)
+                return perturb
+
+            indexed.append(make_wrapper(inner, base_seed))
+
+        return indexed
 
     def _process_tmc(self, manifest_path="tmc_manifest.jsonl"):
         manifest_path = Path(manifest_path).resolve()

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -6,6 +6,7 @@ import json
 import copy
 import xarray as xr
 import inspect
+import itertools
 
 
 class TMCManager:
@@ -20,7 +21,6 @@ class TMCManager:
         # call each factory once to get a closure perturb(model) -> model
         self.perturbations = [factory(self.rng) for factory in perturbations]
 
-
     def run(self, cwd='.', *args, **kwargs):
 
         cwd = Path(cwd).resolve()
@@ -31,31 +31,76 @@ class TMCManager:
 
         # Open TMC manifest for folder structure
         with manifest.open("a") as f_manifest:
-            # Run TMC engine
-            for p_idx, p in enumerate(self.perturbations):
-                for r_idx in range(self.realizations):
 
-                    # fresh copy so perturbations do not accumulate
-                    model_copy = copy.deepcopy(self.base_model)
-                    perturbed_model = p(model_copy)
+            # Run TMC engine in matrix combined perturbations mode
+            for idx_tuple in itertools.product(range(self.realizations), repeat=len(self.perturbations)):
+                # idx_tuple length == p, e.g. (0, 2) for this p=2 example
 
-                    run_dir = cwd / "tmc" / f"perturbation_{p_idx}" / f"realization_{r_idx}"
+                # Copy base model
+                perturbed_model = copy.deepcopy(self.base_model)
+
+                # Apply each perturbation with its corresponding realization index
+
+                # Might need idx as argument for reproducibility, i.e.:
+                # for perturb, ridx in zip(self.perturbations, idx_tuple):
+                #     perturbed_model = perturb(perturbed_model, ridx, self.rng)
+
+                for perturb in self.perturbations:
+                    perturbed_model = perturb(perturbed_model, self.rng)
+
+                    # Create run directory
+                    s = ".".join(map(str, idx_tuple))
+                    run_dir = cwd / "tmc" / f"perturbation_{s}"
                     run_dir.mkdir(parents=True, exist_ok=True)
 
+                    # Run model
                     sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
                     sp_path = Path(sp_path).resolve()
 
-                    # Record in manifest (relative path from cwd)
+                    # Store statepoint path in manifest
                     rec = {
-                        "perturbation": int(p_idx),
-                        "realization": int(r_idx),
-                        "statepoint": str(sp_path.relative_to(cwd)),
-                        # "params": perturbation_params_if_any,
-                    }
+                            "combo_index": s,
+                            "indices": list(idx_tuple),  # [i0, i1, ..., i_{p-1}]
+                            "statepoint": str(sp_path.relative_to(cwd)),
+                        }
                     f_manifest.write(json.dumps(rec) + "\n")
+
+
+    # def run(self, cwd='.', *args, **kwargs):
+
+    #     cwd = Path(cwd).resolve()
+
+    #     # Prepare TMC manifest file
+    #     manifest = cwd / "tmc_manifest.jsonl"
+    #     manifest.parent.mkdir(parents=True, exist_ok=True)
+
+    #     # Open TMC manifest for folder structure
+    #     with manifest.open("a") as f_manifest:
+    #         # Run TMC engine
+    #         for p_idx, p in enumerate(self.perturbations):
+    #             for r_idx in range(self.realizations):
+
+    #                 # fresh copy so perturbations do not accumulate
+    #                 model_copy = copy.deepcopy(self.base_model)
+    #                 perturbed_model = p(model_copy)
+
+    #                 run_dir = cwd / "tmc" / f"perturbation_{p_idx}" / f"realization_{r_idx}"
+    #                 run_dir.mkdir(parents=True, exist_ok=True)
+
+    #                 sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
+    #                 sp_path = Path(sp_path).resolve()
+
+    #                 # Record in manifest (relative path from cwd)
+    #                 rec = {
+    #                     "perturbation": int(p_idx),
+    #                     "realization": int(r_idx),
+    #                     "statepoint": str(sp_path.relative_to(cwd)),
+    #                     # "params": perturbation_params_if_any,
+    #                 }
+    #                 f_manifest.write(json.dumps(rec) + "\n")
         
-        # Postprocess the whole TMC set
-        self._process_tmc(manifest_path=manifest)
+    #     # Postprocess the whole TMC set
+    #     self._process_tmc(manifest_path=manifest)
 
     def _process_tmc(self, manifest_path="tmc_manifest.jsonl"):
         manifest_path = Path(manifest_path).resolve()

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -39,34 +39,60 @@ class TMCManager:
         manifest = cwd / "tmc_manifest.jsonl"
         manifest.parent.mkdir(parents=True, exist_ok=True)
 
-        # If file exists from a previous run, remove it so we can append groups cleanly
+        # If file exists from a previous run, remove it
         if manifest.exists():
             manifest.unlink()
 
-        # Number of perturbations and realizations
         p = len(self.perturbations)
         r = int(self.realizations)
 
-        # Choose index iterator depending on mode
+        # --- Sequential mode: one perturbation active at a time, old behaviour ---
+        if mode == "sequential":
+            with manifest.open("a") as f_manifest:
+                for p_idx, perturb in enumerate(self.perturbations):
+                    for r_idx in range(r):
+                        # fresh copy so perturbations do not accumulate
+                        model_copy = copy.deepcopy(self.base_model)
+
+                        # our current perturbations take (model, idx)
+                        perturbed_model = perturb(model_copy, r_idx)
+
+                        run_dir = cwd / "tmc" / f"perturbation_{p_idx}" / f"realization_{r_idx}"
+                        run_dir.mkdir(parents=True, exist_ok=True)
+
+                        sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
+                        sp_path = Path(sp_path).resolve()
+
+                        rec = {
+                            "perturbation": int(p_idx),
+                            "realization": int(r_idx),
+                            "statepoint": str(sp_path.relative_to(cwd)),
+                            # you can optionally add "mode": "sequential" if you like,
+                            # but _process_tmc already detects this format
+                        }
+                        f_manifest.write(json.dumps(rec) + "\n")
+                        f_manifest.flush()
+
+            self._process_tmc(manifest_path=manifest)
+            return
+
+        # --- Matrix / diagonal modes share the same structure and manifest keys ---
+        # Choose index iterator
         if mode == "matrix":
             # Full r^p Cartesian product
             index_iter = itertools.product(range(r), repeat=p)
         elif mode == "diagonal":
-            # Main diagonal: (0,0,...,0), (1,1,...,1), ..., (r-1,...,r-1)
+            # Main diagonal: (0,0,...,0), (1,1,...,1), ...
             index_iter = (tuple([k] * p) for k in range(r))
-        elif mode == "sequential":
-            raise NotImplementedError("sequential mode not implemented in this version")
         else:
             raise ValueError(f"Unknown TMC mode {mode!r}")
 
-        # Open TMC manifest for folder structure
         with manifest.open("a") as f_manifest:
-            # Run TMC engine
             for idx_tuple in index_iter:
                 # Copy base model
                 perturbed_model = copy.deepcopy(self.base_model)
 
-                # Apply each perturbation with its corresponding realization index
+                # Apply all perturbations to the same model with their indices
                 for perturb, ridx in zip(self.perturbations, idx_tuple):
                     perturbed_model = perturb(perturbed_model, ridx)
 
@@ -81,7 +107,7 @@ class TMCManager:
 
                 # Store statepoint path in manifest
                 rec = {
-                    "mode": mode,                  # <-- so _process_tmc can see matrix vs diagonal
+                    "mode": mode,                  # "matrix" or "diagonal"
                     "indices": list(idx_tuple),    # [i0, i1, ..., i_{p-1}]
                     "statepoint": str(sp_path.relative_to(cwd)),
                 }

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -11,15 +11,36 @@ import itertools
 
 class TMCManager:
     def __init__(self, base_model: openmc.Model, perturbations: List[Callable],
-                  realizations:int, rng:np.random._generator.Generator=None):
-        self.base_model = base_model
-        # self.perturbations = perturbations
-        self.realizations = realizations
-        self.rng = rng or np.random.default_rng()
+                realizations:int, seed: int | None = None, 
+                rng: np.random.Generator | None = None):
 
+        if rng is not None and seed is not None:
+            raise ValueError("Pass either seed or rng, not both.")
+
+        if rng is None:
+            if seed is None:
+                seed = 123456  # or from config
+            self.master_rng = np.random.default_rng(seed)
+        else:
+            self.master_rng = rng
+        
+        if rng is not None:
+            self.rng = rng
+        else:
+            self.rng = np.random.default_rng(seed)
+
+        self.base_model = base_model
+        self.realizations = realizations
+        
         # perturbations is a list of factories: factory(rng) -> perturb(model)
         # call each factory once to get a closure perturb(model) -> model
-        self.perturbations = [factory(self.rng) for factory in perturbations]
+        perts = []
+        for factory in perturbations:
+            base_seed = int(self.master_rng.integers(0, 2**31))
+            perturb = factory(base_seed)
+            perts.append(perturb)
+        
+        self.perturbations = perts
 
     def run(self, cwd='.', *args, **kwargs):
 
@@ -45,8 +66,8 @@ class TMCManager:
                 # for perturb, ridx in zip(self.perturbations, idx_tuple):
                 #     perturbed_model = perturb(perturbed_model, ridx, self.rng)
 
-                for perturb in self.perturbations:
-                    perturbed_model = perturb(perturbed_model, self.rng)
+                for pert, ridx in zip(self.perturbations, idx_tuple):
+                    perturbed_model = pert(perturbed_model, ridx)
 
                     # Create run directory
                     s = ".".join(map(str, idx_tuple))
@@ -54,7 +75,12 @@ class TMCManager:
                     run_dir.mkdir(parents=True, exist_ok=True)
 
                     # Run model
-                    sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
+                    # sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
+
+                    print(s)  # delete later
+                    sp_path = run_dir / "model.xml"  # delete later
+                    perturbed_model.export_to_model_xml(str(sp_path))  # delete later
+
                     sp_path = Path(sp_path).resolve()
 
                     # Store statepoint path in manifest
@@ -64,43 +90,6 @@ class TMCManager:
                             "statepoint": str(sp_path.relative_to(cwd)),
                         }
                     f_manifest.write(json.dumps(rec) + "\n")
-
-
-    # def run(self, cwd='.', *args, **kwargs):
-
-    #     cwd = Path(cwd).resolve()
-
-    #     # Prepare TMC manifest file
-    #     manifest = cwd / "tmc_manifest.jsonl"
-    #     manifest.parent.mkdir(parents=True, exist_ok=True)
-
-    #     # Open TMC manifest for folder structure
-    #     with manifest.open("a") as f_manifest:
-    #         # Run TMC engine
-    #         for p_idx, p in enumerate(self.perturbations):
-    #             for r_idx in range(self.realizations):
-
-    #                 # fresh copy so perturbations do not accumulate
-    #                 model_copy = copy.deepcopy(self.base_model)
-    #                 perturbed_model = p(model_copy)
-
-    #                 run_dir = cwd / "tmc" / f"perturbation_{p_idx}" / f"realization_{r_idx}"
-    #                 run_dir.mkdir(parents=True, exist_ok=True)
-
-    #                 sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
-    #                 sp_path = Path(sp_path).resolve()
-
-    #                 # Record in manifest (relative path from cwd)
-    #                 rec = {
-    #                     "perturbation": int(p_idx),
-    #                     "realization": int(r_idx),
-    #                     "statepoint": str(sp_path.relative_to(cwd)),
-    #                     # "params": perturbation_params_if_any,
-    #                 }
-    #                 f_manifest.write(json.dumps(rec) + "\n")
-        
-    #     # Postprocess the whole TMC set
-    #     self._process_tmc(manifest_path=manifest)
 
     def _process_tmc(self, manifest_path="tmc_manifest.jsonl"):
         manifest_path = Path(manifest_path).resolve()

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -7,6 +7,7 @@ import copy
 import xarray as xr
 import inspect
 import itertools
+import h5py
 
 
 class TMCManager:
@@ -108,6 +109,10 @@ class TMCManager:
         # xarray will write NetCDF (HDF5-backed); extension is up to you
         tmc_statepoint = tmc_dir / f"tmc_statepoint.{int(self.realizations)}.h5"
 
+        # If file exists from a previous run, remove it so we can append groups cleanly
+        if tmc_statepoint.exists():
+            tmc_statepoint.unlink()
+
         # ---- helper: resolve statepoint path robustly ----
         def resolve_statepoint_path(sp_str: str) -> Path:
             sp_path = Path(sp_str)
@@ -163,20 +168,21 @@ class TMCManager:
             # number of perturbations = length of indices
             p = len(first_rec["indices"])
 
-            # In the matrix TMC driver, you used:
-            #   for idx_tuple in itertools.product(range(self.realizations), repeat=p):
-            # so each perturbation dimension has length self.realizations
-            r = int(self.realizations)
-            extra_shape = tuple(r for _ in range(p))  # (r, r, ..., r)
+            # Infer per-dimension sizes from the data:
+            indices_array = np.array([rec["indices"] for rec in records], dtype=int)
+            # assume indices run from 0..(n_i-1) along each axis
+            per_dim_sizes = indices_array.max(axis=0) + 1  # length per perturbation dim
+
+            extra_shape = tuple(int(n) for n in per_dim_sizes)
             extra_dims = tuple(f"perturbation_{i}" for i in range(p))
-            extra_coords = {dim: np.arange(r) for dim in extra_dims}
+            extra_coords = {dim: np.arange(n) for dim, n in zip(extra_dims, extra_shape)}
 
             n_combos = len(records)
-            expected_combos = r ** p
+            expected_combos = int(np.prod(extra_shape))
             if n_combos != expected_combos:
                 raise RuntimeError(
-                    f"Matrix TMC manifest has {n_combos} runs, but expected {expected_combos} "
-                    f"for realizations={r}, perturbations={p}."
+                    f"Matrix TMC manifest has {n_combos} runs, but inferred grid shape "
+                    f"{extra_shape} implies {expected_combos} combinations."
                 )
 
         # ---- 3. Use first statepoint as reference for tallies ----
@@ -272,63 +278,82 @@ class TMCManager:
                 arr.shape = extra_shape + tally_shapes[tid]
                 tmc_mc_std[tid][...] = arr
 
-        # ---- 6. Build xarray Dataset and write ----
-        ds = xr.Dataset()
+        # ---- 6. Build per-tally Datasets and write each into its own group ----
+
+        # We'll use h5netcdf or netcdf4 so that group=... works.
+        # Each tally_id gets a group: /tally_<tid>/ with variables: mean, mc_std.
 
         for tid, arr in tmc_data.items():
             nd_shape = tally_shapes[tid]
             filters = tally_filters[tid]
+            axisinfo = tally_axisinfo[tid]
 
-            # Filter dims based on filter types
+            # filter dims based on filter types
             filter_dims = []
             for f in filters:
                 filter_type = type(f).__name__.replace("Filter", "").lower()
                 filter_dims.append(filter_type)
 
-            nuclide_dim = f"nuclide_{tid}"
-            score_dim = f"score_{tid}"
+            # within each tally group, we can use generic "nuclide" and "score"
+            dims = extra_dims + tuple(filter_dims) + ("nuclide", "score")
 
-            dims = extra_dims + tuple(filter_dims) + (nuclide_dim, score_dim)
-
+            # coords: TMC dims
             coords = dict(extra_coords)
 
-            tally_name = tally_names[tid] or f"tally_{tid}"
+            # coords: nuclide / score for this tally
+            nuclides = axisinfo["nuclides"]
+            scores   = axisinfo["scores"]
 
-            da = xr.DataArray(
+            coords["nuclide"] = ("nuclide", np.array(nuclides, dtype="U"))
+            coords["score"]   = ("score",   np.array(scores,   dtype="U"))
+
+            # Per-tally dataset
+            ds_tid = xr.Dataset()
+
+            da_mean = xr.DataArray(
                 arr,
                 dims=dims,
                 coords=coords,
-                name=tally_name,
+                name="mean",
             )
 
             da_mc_std = xr.DataArray(
                 tmc_mc_std[tid],
                 dims=dims,
                 coords=coords,
-                name=f"{tally_name}_mc_std",
+                name="mc_std",
             )
 
-            da.attrs["tally_id"] = tid
-            da.attrs["tally_name"] = tally_names[tid]
-            da_mc_std.attrs["tally_id"] = tid
-            da_mc_std.attrs["tally_name"] = tally_names[tid]
+            # basic attrs
+            tally_name = tally_names[tid] or f"tally_{tid}"
+            for target_da in (da_mean, da_mc_std):
+                target_da.attrs["tally_id"] = tid
+                target_da.attrs["tally_name"] = tally_name
 
-            axisinfo = tally_axisinfo[tid]
-            for target_da in (da, da_mc_std):
-                for k, v in axisinfo.items():
-                    if isinstance(v, (int, float, bool, str, np.number)):
-                        target_da.attrs[k] = v
+            # serialize complex axisinfo at dataset level
+            for k, v in axisinfo.items():
+                if isinstance(v, (int, float, bool, str, np.number)):
+                    ds_tid.attrs[k] = v
+                else:
+                    if isinstance(v, np.ndarray):
+                        to_dump = v.tolist()
                     else:
-                        if isinstance(v, np.ndarray):
-                            to_dump = v.tolist()
-                        else:
-                            to_dump = v
-                        target_da.attrs[k] = json.dumps(to_dump)
+                        to_dump = v
+                    ds_tid.attrs[k] = json.dumps(to_dump)
 
-            ds[da.name] = da
-            ds[da_mc_std.name] = da_mc_std
+            ds_tid["mean"] = da_mean
+            ds_tid["mc_std"] = da_mc_std
 
-        ds.to_netcdf(tmc_statepoint)
+            group_name = f"tally_{tid}"
+
+            # append this tally-dataset as a group in the same file
+            ds_tid.to_netcdf(
+                tmc_statepoint,
+                mode="a",
+                group=group_name,
+                engine="h5netcdf",  # or "netcdf4"
+            )
+
         self.tmc_statepoint_path = tmc_statepoint
 
     def get_tmc_statepoint(self, path=None):
@@ -358,187 +383,258 @@ class TMCManager:
 
 class TMCStatePoint:
     """
-    Wrapper for TMC statepoint providing OpenMC StatePoint-like interface.
-    
+    Wrapper for TMC statepoint providing an OpenMC StatePoint-like interface.
+
     Parameters
     ----------
     path : str or Path
         Path to the TMC statepoint NetCDF/HDF5 file.
     """
-    
+
     def __init__(self, path):
         self.path = Path(path).resolve()
-        self._ds = xr.open_dataset(self.path)
+        # We won't keep one global ds; we'll open per-tally groups as needed.
         self._tallies = None
-        
+
     @property
     def tallies(self):
         """Dictionary of tallies, indexed by tally ID (mimics openmc.StatePoint.tallies)."""
         if self._tallies is None:
             self._tallies = {}
-            for var_name in self._ds.data_vars:
-                # Skip MC std arrays (they're accessed via the main tally)
-                if var_name.endswith('_mc_std'):
-                    continue
-                da = self._ds[var_name]
-                tally_id = da.attrs.get('tally_id')
-                if tally_id is not None:
-                    self._tallies[tally_id] = TMCTally(da, parent_ds=self._ds)
+            # Discover tally groups via h5py
+            with h5py.File(self.path, "r") as f:
+                for group_name in f.keys():
+                    if not group_name.startswith("tally_"):
+                        continue
+                    # Open this group as an xarray Dataset
+                    ds = xr.open_dataset(
+                        self.path,
+                        group=group_name,
+                        engine="h5netcdf",
+                    )
+                    if "mean" not in ds:
+                        continue
+                    da_mean = ds["mean"]
+                    da_mc_std = ds["mc_std"] if "mc_std" in ds else None
+
+                    tally_id = da_mean.attrs.get("tally_id")
+                    if tally_id is None:
+                        # Fallback: parse id from group name
+                        try:
+                            tally_id = int(group_name.split("_", 1)[1])
+                        except Exception:
+                            continue
+
+                    self._tallies[tally_id] = TMCTally(da_mean, da_mc_std, parent_ds=ds)
         return self._tallies
-    
+
     def get_tally(self, tally_id=None, name=None):
         """
         Get a tally by ID or name (mimics openmc.StatePoint.get_tally).
-        
+
         Parameters
         ----------
-        id : int, optional
+        tally_id : int, optional
             Tally ID
         name : str, optional
             Tally name
-            
+
         Returns
         -------
         TMCTally
             The requested tally
         """
         if tally_id is not None:
-            return self.tallies[tally_id]
+            try:
+                return self.tallies[tally_id]
+            except KeyError:
+                raise ValueError(f"No tally with id '{tally_id}' found")
         elif name is not None:
             for tally in self.tallies.values():
                 if tally.name == name:
                     return tally
             raise ValueError(f"No tally with name '{name}' found")
         else:
-            raise ValueError("Must specify either 'id' or 'name'")
-    
+            raise ValueError("Must specify either 'tally_id' or 'name'")
+
     def close(self):
-        """Close the underlying NetCDF file."""
-        self._ds.close()
-        
+        """No persistent open Dataset to close, but keep for API symmetry."""
+        # If you decide to cache per-group ds objects, close them here.
+        pass
+
     def __enter__(self):
         return self
-        
+
     def __exit__(self, *args):
         self.close()
-        
+
     def __repr__(self):
         n_tallies = len(self.tallies)
-        n_realizations = self._ds.dims.get('realization', 0)
-        return f"<TMCStatePoint: {n_realizations} realizations, {n_tallies} tallies>"
+        # Try to infer "realizations" (or more generally TMC size along first dim)
+        n_realizations = 0
+        if self.tallies:
+            any_tally = next(iter(self.tallies.values()))
+            tmc_dims = any_tally._tmc_dims
+            if tmc_dims:
+                # product of TMC dims sizes
+                sz = 1
+                for d in tmc_dims:
+                    sz *= any_tally._da.sizes[d]
+                n_realizations = sz
+        return f"<TMCStatePoint: {n_realizations} TMC combinations, {n_tallies} tallies>"
 
 
 class TMCTally:
     """
-    Wrapper for a single TMC tally providing OpenMC Tally-like interface.
-    
+    Wrapper for a single TMC tally providing an OpenMC Tally-like interface.
+
     Parameters
     ----------
-    data_array : xarray.DataArray
-        The DataArray containing the TMC tally data
+    mean_da : xarray.DataArray
+        The DataArray containing the TMC mean values for this tally.
+    mc_std_da : xarray.DataArray, optional
+        The DataArray containing the MC std dev per run/combo.
     parent_ds : xarray.Dataset, optional
-        Parent dataset containing MC uncertainty data
+        Parent dataset (group) containing metadata attributes.
     """
-    
-    def __init__(self, data_array, parent_ds=None):
-        self._da = data_array
+
+    def __init__(self, mean_da, mc_std_da=None, parent_ds=None):
+        self._da = mean_da
+        self._da_mc_std = mc_std_da
         self._parent_ds = parent_ds
-        
+
+        # Identify TMC dimensions: "realization" for sequential, "perturbation_*" for matrix
+        self._tmc_dims = [
+            d for d in self._da.dims
+            if d == "realization" or d.startswith("perturbation_")
+        ]
+
     @property
     def id(self):
         """Tally ID."""
-        return self._da.attrs.get('tally_id')
-    
+        return self._da.attrs.get("tally_id")
+
     @property
     def name(self):
         """Tally name."""
-        return self._da.attrs.get('tally_name')
-    
+        return self._da.attrs.get("tally_name")
+
+    # --- TMC statistics ---
+
     @property
     def mean(self):
-        """TMC mean: mean value across all realizations."""
-        return self._da.mean(dim='realization').values
-    
+        """
+        TMC mean across all TMC dimensions (realization / perturbation_*).
+        """
+        if not self._tmc_dims:
+            return self._da.values
+        return self._da.mean(dim=self._tmc_dims).values
+
     @property
     def std_dev(self):
-        """TMC standard deviation: propagated parametric uncertainty across realizations."""
-        return self._da.std(dim='realization').values
-    
+        """
+        TMC standard deviation across all TMC dimensions.
+
+        This is the propagated parametric uncertainty from the ensemble,
+        not the MC sampling error within each run.
+        """
+        if not self._tmc_dims:
+            return np.zeros_like(self._da.values)
+        return self._da.std(dim=self._tmc_dims).values
+
     @property
     def realization_means(self):
-        """Mean value for each individual realization (shape: n_realizations x ...)."""
+        """
+        Raw mean value for each TMC point (all TMC dims retained).
+        Shape: (TMC dims..., filters..., nuclide, score).
+        """
         return self._da.values
-    
+
     @property
     def realization_stds(self):
         """
-        Monte Carlo standard deviation for each individual realization.
-        
+        Monte Carlo standard deviation for each run/combo.
+
         This is the statistical uncertainty from particle sampling within each
-        individual OpenMC run (shape: n_realizations x ...).
+        individual OpenMC run, shaped like self._da.
         """
-        # Get the corresponding MC std DataArray from the parent dataset
-        mc_std_name = f"{self._da.name}_mc_std"
-        if hasattr(self._da, '_parent_ds') and mc_std_name in self._da._parent_ds:
-            return self._da._parent_ds[mc_std_name].values
-        # Fallback: try to find it in the same file
-        try:
-            ds = xr.open_dataset(self._da.encoding.get('source', ''))
-            if mc_std_name in ds:
-                return ds[mc_std_name].values
-        except:
-            pass
-        # If not found, return zeros as fallback
+        if self._da_mc_std is not None:
+            return self._da_mc_std.values
+
+        # Fallback to zeros if not available
         return np.zeros_like(self._da.values)
-    
+
+    # --- Metadata & helpers ---
+
     @property
     def data(self):
-        """Full TMC data array (all realizations)."""
+        """Full TMC mean data array (all TMC entries)."""
         return self._da.values
-    
+
     @property
     def scores(self):
         """List of score names."""
-        scores_json = self._da.attrs.get('scores')
+        # Preferred: from 'score' coordinate, if present
+        if "score" in self._da.coords:
+            return [str(s) for s in self._da.coords["score"].values]
+
+        # Fallback: from parent_ds attrs "scores" (JSON)
+        if self._parent_ds is not None:
+            scores_json = self._parent_ds.attrs.get("scores")
+            if scores_json:
+                return json.loads(scores_json)
+        # Last resort: from variable attrs (if you changed writer)
+        scores_json = self._da.attrs.get("scores")
         if scores_json:
             return json.loads(scores_json)
         return []
-    
+
     @property
     def nuclides(self):
         """List of nuclide names."""
-        nuclides_json = self._da.attrs.get('nuclides')
+        if "nuclide" in self._da.coords:
+            return [str(n) for n in self._da.coords["nuclide"].values]
+
+        if self._parent_ds is not None:
+            nuclides_json = self._parent_ds.attrs.get("nuclides")
+            if nuclides_json:
+                return json.loads(nuclides_json)
+        nuclides_json = self._da.attrs.get("nuclides")
         if nuclides_json:
             return json.loads(nuclides_json)
         return []
-    
+
     @property
     def filters(self):
         """List of filter information (type and number of bins)."""
-        filters_json = self._da.attrs.get('filter_axes')
-        if filters_json:
-            return json.loads(filters_json)
+        if self._parent_ds is not None:
+            filt_json = self._parent_ds.attrs.get("filter_axes")
+            if filt_json:
+                return json.loads(filt_json)
+        filt_json = self._da.attrs.get("filter_axes")
+        if filt_json:
+            return json.loads(filt_json)
         return []
-    
+
     @property
-    def realizations(self):
-        """Number of TMC realizations."""
-        return self._da.sizes.get('realization', 0)
-    
+    def tmc_dims(self):
+        """Names of TMC dimensions (realization / perturbation_*)."""
+        return tuple(self._tmc_dims)
+
     @property
     def shape(self):
-        """Shape of the data array."""
+        """Shape of the underlying mean data array."""
         return self._da.shape
-    
+
     @property
     def dims(self):
-        """Dimension names."""
+        """Dimension names of the underlying mean data array."""
         return self._da.dims
-    
+
     def get_slice(self, scores=None, nuclides=None, **filter_kwargs):
         """
         Get a slice of the TMC data with optional filtering.
-        
+
         Parameters
         ----------
         scores : list of str, optional
@@ -547,31 +643,31 @@ class TMCTally:
             Nuclide names to select
         **filter_kwargs : optional
             Additional dimension filters (e.g., energy=slice(0, 10))
-            
+
         Returns
         -------
         xarray.DataArray
-            Filtered TMC data
+            Filtered TMC mean data
         """
         da = self._da
-        
-        # Apply filter dimension selections
+
+        # Apply filter dimension selections (energy, cell, mesh, perturbation_x, etc.)
         if filter_kwargs:
             da = da.sel(**filter_kwargs)
-            
+
         # Apply score selection
-        if scores is not None:
+        if scores is not None and "score" in da.dims:
             all_scores = self.scores
             score_indices = [all_scores.index(s) for s in scores]
             da = da.isel(score=score_indices)
-            
+
         # Apply nuclide selection
-        if nuclides is not None:
+        if nuclides is not None and "nuclide" in da.dims:
             all_nuclides = self.nuclides
             nuclide_indices = [all_nuclides.index(n) for n in nuclides]
             da = da.isel(nuclide=nuclide_indices)
-            
+
         return da
-    
+
     def __repr__(self):
         return f"<TMCTally {self.id}: '{self.name}', shape={self.shape}>"

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -31,7 +31,7 @@ class TMCManager:
        # Wrap user perturbations into indexed perturb(model, idx)
         self.perturbations = self._build_indexed_perturbations(perturbations)
 
-    def run(self, cwd='.', *args, **kwargs):
+    def run(self, mode="matrix", cwd='.', *args, **kwargs):
 
         cwd = Path(cwd).resolve()
 
@@ -39,22 +39,38 @@ class TMCManager:
         manifest = cwd / "tmc_manifest.jsonl"
         manifest.parent.mkdir(parents=True, exist_ok=True)
 
+        # If file exists from a previous run, remove it so we can append groups cleanly
+        if manifest.exists():
+            manifest.unlink()
+
+        # Number of perturbations and realizations
+        p = len(self.perturbations)
+        r = int(self.realizations)
+
+        # Choose index iterator depending on mode
+        if mode == "matrix":
+            # Full r^p Cartesian product
+            index_iter = itertools.product(range(r), repeat=p)
+        elif mode == "diagonal":
+            # Main diagonal: (0,0,...,0), (1,1,...,1), ..., (r-1,...,r-1)
+            index_iter = (tuple([k] * p) for k in range(r))
+        elif mode == "sequential":
+            raise NotImplementedError("sequential mode not implemented in this version")
+        else:
+            raise ValueError(f"Unknown TMC mode {mode!r}")
+
         # Open TMC manifest for folder structure
         with manifest.open("a") as f_manifest:
-
-            # Run TMC engine in matrix combined perturbations mode
-            for idx_tuple in itertools.product(range(self.realizations),
-                                            repeat=len(self.perturbations)):
-                # idx_tuple length == p, e.g. (0, 2) for p=2
-
+            # Run TMC engine
+            for idx_tuple in index_iter:
                 # Copy base model
                 perturbed_model = copy.deepcopy(self.base_model)
 
                 # Apply each perturbation with its corresponding realization index
-                for pert, ridx in zip(self.perturbations, idx_tuple):
-                    perturbed_model = pert(perturbed_model, ridx)
+                for perturb, ridx in zip(self.perturbations, idx_tuple):
+                    perturbed_model = perturb(perturbed_model, ridx)
 
-                # NOW run once per idx_tuple, after all perturbations have been applied
+                # Directory name encoding the index tuple
                 s = ".".join(map(str, idx_tuple))
                 run_dir = cwd / "tmc" / f"perturbation_{s}"
                 run_dir.mkdir(parents=True, exist_ok=True)
@@ -65,7 +81,8 @@ class TMCManager:
 
                 # Store statepoint path in manifest
                 rec = {
-                    "indices": list(idx_tuple),  # [i0, i1, ..., i_{p-1}]
+                    "mode": mode,                  # <-- so _process_tmc can see matrix vs diagonal
+                    "indices": list(idx_tuple),    # [i0, i1, ..., i_{p-1}]
                     "statepoint": str(sp_path.relative_to(cwd)),
                 }
                 f_manifest.write(json.dumps(rec) + "\n")
@@ -142,10 +159,11 @@ class TMCManager:
         if not records:
             raise RuntimeError("TMC manifest is empty; no runs to process")
 
-        # Detect mode: old sequential vs new matrix
+        # Detect mode: sequential vs diagonal vs matrix
         first_rec = records[0]
         if "indices" in first_rec:
-            mode = "matrix"
+            # new: allow explicit "mode" in manifest for diagonal vs full matrix
+            mode = first_rec.get("mode", "matrix")  # default to matrix if not specified
         elif "perturbation" in first_rec and "realization" in first_rec:
             mode = "sequential"
         else:
@@ -159,6 +177,15 @@ class TMCManager:
             extra_shape = (n_realizations,)
             extra_dims = ("realization",)
             extra_coords = {"realization": np.arange(n_realizations)}
+
+        elif mode == "diagonal":
+            # Diagonal matrix mode: indices are present but we treat them as a 1D TMC dim
+            # e.g. idx_tuple = (k, k, ..., k) for k in range(realizations)
+            records.sort(key=lambda r: tuple(r["indices"]))
+            n_points = len(records)
+            extra_shape = (n_points,)
+            extra_dims = ("realization",)
+            extra_coords = {"realization": np.arange(n_points)}
 
         else:  # mode == "matrix"
             # each record: {"indices": [i0, i1, ..., i_{p-1}], "statepoint": ...}
@@ -233,7 +260,8 @@ class TMCManager:
             tmc_mc_std[tid] = np.empty(full_shape, dtype=float)
 
         # ---- 5. Fill arrays by looping over statepoints ----
-        if mode == "sequential":
+        if mode in ("sequential", "diagonal"):
+            # same shape logic: one 1D TMC dim called "realization"
             for i, rec in enumerate(records):
                 sp_path = resolve_statepoint_path(rec["statepoint"])
                 with openmc.StatePoint(str(sp_path)) as sp:
@@ -279,9 +307,6 @@ class TMCManager:
                 tmc_mc_std[tid][...] = arr
 
         # ---- 6. Build per-tally Datasets and write each into its own group ----
-
-        # We'll use h5netcdf or netcdf4 so that group=... works.
-        # Each tally_id gets a group: /tally_<tid>/ with variables: mean, mc_std.
 
         for tid, arr in tmc_data.items():
             nd_shape = tally_shapes[tid]

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -519,51 +519,6 @@ class TMCTally:
         """Tally name."""
         return self._da.attrs.get("tally_name")
 
-    # --- TMC statistics ---
-
-    @property
-    def mean(self):
-        """
-        TMC mean across all TMC dimensions (realization / perturbation_*).
-        """
-        if not self._tmc_dims:
-            return self._da.values
-        return self._da.mean(dim=self._tmc_dims).values
-
-    @property
-    def std_dev(self):
-        """
-        TMC standard deviation across all TMC dimensions.
-
-        This is the propagated parametric uncertainty from the ensemble,
-        not the MC sampling error within each run.
-        """
-        if not self._tmc_dims:
-            return np.zeros_like(self._da.values)
-        return self._da.std(dim=self._tmc_dims).values
-
-    @property
-    def realization_means(self):
-        """
-        Raw mean value for each TMC point (all TMC dims retained).
-        Shape: (TMC dims..., filters..., nuclide, score).
-        """
-        return self._da.values
-
-    @property
-    def realization_stds(self):
-        """
-        Monte Carlo standard deviation for each run/combo.
-
-        This is the statistical uncertainty from particle sampling within each
-        individual OpenMC run, shaped like self._da.
-        """
-        if self._da_mc_std is not None:
-            return self._da_mc_std.values
-
-        # Fallback to zeros if not available
-        return np.zeros_like(self._da.values)
-
     # --- Metadata & helpers ---
 
     @property
@@ -630,6 +585,149 @@ class TMCTally:
     def dims(self):
         """Dimension names of the underlying mean data array."""
         return self._da.dims
+    
+        # --- TMC statistics ---
+
+    @property
+    def mean(self):
+        """
+        TMC mean across all TMC dimensions (realization / perturbation_*).
+        """
+        if not self._tmc_dims:
+            return self._da.values
+        return self._da.mean(dim=self._tmc_dims).values
+
+    @property
+    def std_dev(self):
+        """
+        TMC standard deviation across all TMC dimensions.
+
+        This is the propagated parametric uncertainty from the ensemble,
+        not the MC sampling error within each run.
+        """
+        if not self._tmc_dims:
+            return np.zeros_like(self._da.values)
+        return self._da.std(dim=self._tmc_dims).values
+
+    @property
+    def per_realization_mean(self):
+        """
+        Raw mean value for each TMC point (all TMC dims retained).
+        Shape: (TMC dims..., filters..., nuclide, score).
+        """
+        return self._da.values
+
+    @property
+    def per_realization_std_dev(self):
+        """
+        Monte Carlo standard deviation for each run/combo.
+
+        This is the statistical uncertainty from particle sampling within each
+        individual OpenMC run, shaped like self._da.
+        """
+        if self._da_mc_std is not None:
+            return self._da_mc_std.values
+
+        # Fallback to zeros if not available
+        return np.zeros_like(self._da.values)
+    
+    @property
+    def perturbation_dims(self):
+        """Names of perturbation dimensions in matrix mode (e.g. 'perturbation_0', ...)."""
+        return tuple(d for d in self._tmc_dims if d.startswith("perturbation_"))
+    
+    @property
+    def per_perturbation_mean(self, perturbation_dim=None, as_xarray=False):
+        """
+        Mean per perturbation dimension, marginalised over other perturbation dims.
+
+        In matrix mode:
+          - If perturbation_dim is None: returns a dict {dim_name: np.ndarray}
+            where each array has dims (that dim, physical dims...).
+          - If perturbation_dim is given (e.g. 'perturbation_0'):
+            returns just that array.
+
+        In sequential mode (only 'realization' TMC dim):
+          - Equivalent to t.mean (no separate per-perturbation concept).
+
+        Parameters
+        ----------
+        perturbation_dim : str, optional
+            Name of a specific perturbation dimension to extract.
+        as_xarray : bool, optional
+            If True, return xarray.DataArray(s) instead of plain numpy arrays.
+
+        Returns
+        -------
+        dict[str, np.ndarray] or np.ndarray or xarray.DataArray
+        """
+        pert_dims = self.perturbation_dims
+        if not pert_dims:
+            # sequential mode: only 'realization'
+            if perturbation_dim is not None:
+                raise ValueError("No perturbation_* dims in this tally (likely sequential mode).")
+            return self.mean if not as_xarray else self._da.mean(dim=self._tmc_dims)
+
+        # helper: compute for one dim
+        def _one_dim(dim):
+            other_pert_dims = [d for d in pert_dims if d != dim]
+            if other_pert_dims:
+                da_red = self._da.mean(dim=other_pert_dims)
+            else:
+                da_red = self._da
+            return da_red if as_xarray else da_red.values
+
+        if perturbation_dim is not None:
+            if perturbation_dim not in pert_dims:
+                raise ValueError(f"{perturbation_dim!r} is not a perturbation dimension in {pert_dims}")
+            return _one_dim(perturbation_dim)
+
+        # all perturbation dims
+        return {dim: _one_dim(dim) for dim in pert_dims}
+    
+    @property
+    def per_perturbation_std_dev(self, perturbation_dim=None, as_xarray=False):
+        """
+        Std dev per perturbation dimension, marginalised over other perturbation dims.
+
+        In matrix mode:
+          - If perturbation_dim is None: returns a dict {dim_name: np.ndarray}
+          - If perturbation_dim is given: returns just that array.
+
+        In sequential mode:
+          - Equivalent to t.std_dev.
+
+        Parameters
+        ----------
+        perturbation_dim : str, optional
+            Name of a specific perturbation dimension to extract.
+        as_xarray : bool, optional
+            If True, return xarray.DataArray(s) instead of plain numpy arrays.
+
+        Returns
+        -------
+        dict[str, np.ndarray] or np.ndarray or xarray.DataArray
+        """
+        pert_dims = self.perturbation_dims
+        if not pert_dims:
+            if perturbation_dim is not None:
+                raise ValueError("No perturbation_* dims in this tally (likely sequential mode).")
+            return self.std_dev if not as_xarray else self._da.std(dim=self._tmc_dims)
+
+        def _one_dim(dim):
+            other_pert_dims = [d for d in pert_dims if d != dim]
+            if other_pert_dims:
+                da_red = self._da.std(dim=other_pert_dims)
+            else:
+                da_red = self._da * 0.0  # only one TMC point along that dim; std=0
+            return da_red if as_xarray else da_red.values
+
+        if perturbation_dim is not None:
+            if perturbation_dim not in pert_dims:
+                raise ValueError(f"{perturbation_dim!r} is not a perturbation dimension in {pert_dims}")
+            return _one_dim(perturbation_dim)
+
+        return {dim: _one_dim(dim) for dim in pert_dims}
 
     def get_slice(self, scores=None, nuclides=None, **filter_kwargs):
         """
@@ -668,6 +766,7 @@ class TMCTally:
             da = da.isel(nuclide=nuclide_indices)
 
         return da
+
 
     def __repr__(self):
         return f"<TMCTally {self.id}: '{self.name}', shape={self.shape}>"

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -42,8 +42,9 @@ class TMCManager:
         with manifest.open("a") as f_manifest:
 
             # Run TMC engine in matrix combined perturbations mode
-            for idx_tuple in itertools.product(range(self.realizations), repeat=len(self.perturbations)):
-                # idx_tuple length == p, e.g. (0, 2) for this p=2 example
+            for idx_tuple in itertools.product(range(self.realizations),
+                                            repeat=len(self.perturbations)):
+                # idx_tuple length == p, e.g. (0, 2) for p=2
 
                 # Copy base model
                 perturbed_model = copy.deepcopy(self.base_model)
@@ -52,22 +53,25 @@ class TMCManager:
                 for pert, ridx in zip(self.perturbations, idx_tuple):
                     perturbed_model = pert(perturbed_model, ridx)
 
-                    # Create run directory
-                    s = ".".join(map(str, idx_tuple))
-                    run_dir = cwd / "tmc" / f"perturbation_{s}"
-                    run_dir.mkdir(parents=True, exist_ok=True)
+                # NOW run once per idx_tuple, after all perturbations have been applied
+                s = ".".join(map(str, idx_tuple))
+                run_dir = cwd / "tmc" / f"perturbation_{s}"
+                run_dir.mkdir(parents=True, exist_ok=True)
 
-                    # Run model
-                    sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
-                    sp_path = Path(sp_path).resolve()
+                # Run model
+                sp_path = perturbed_model.run(cwd=run_dir, *args, **kwargs)
+                sp_path = Path(sp_path).resolve()
 
-                    # Store statepoint path in manifest
-                    rec = {
-                            "indices": list(idx_tuple),  # [i0, i1, ..., i_{p-1}]
-                            "statepoint": str(sp_path.relative_to(cwd)),
-                        }
-                    f_manifest.write(json.dumps(rec) + "\n")
-                    f_manifest.flush()
+                # Store statepoint path in manifest
+                rec = {
+                    "indices": list(idx_tuple),  # [i0, i1, ..., i_{p-1}]
+                    "statepoint": str(sp_path.relative_to(cwd)),
+                }
+                f_manifest.write(json.dumps(rec) + "\n")
+                f_manifest.flush()
+
+        # Postprocess the whole TMC set
+        self._process_tmc(manifest_path=manifest)
 
     def _build_indexed_perturbations(self, user_factories):
         """
@@ -99,12 +103,28 @@ class TMCManager:
 
     def _process_tmc(self, manifest_path="tmc_manifest.jsonl"):
         manifest_path = Path(manifest_path).resolve()
-        tmc_dir = manifest_path.parent
+        tmc_dir = manifest_path.parent  # directory containing the manifest
 
         # xarray will write NetCDF (HDF5-backed); extension is up to you
         tmc_statepoint = tmc_dir / f"tmc_statepoint.{int(self.realizations)}.h5"
 
-        # ---- 1. Read TMC manifest ----
+        # ---- helper: resolve statepoint path robustly ----
+        def resolve_statepoint_path(sp_str: str) -> Path:
+            sp_path = Path(sp_str)
+            if sp_path.is_absolute():
+                return sp_path
+            # Try relative to manifest dir
+            cand1 = tmc_dir / sp_path
+            if cand1.exists():
+                return cand1
+            # Try relative to parent of manifest dir (project root)
+            cand2 = tmc_dir.parent / sp_path
+            if cand2.exists():
+                return cand2
+            # Fallback: plain resolve (current CWD)
+            return sp_path.resolve()
+
+        # ---- 1. Read manifest ----
         records = []
         with manifest_path.open() as f:
             for line in f:
@@ -114,18 +134,57 @@ class TMCManager:
                 rec = json.loads(line)
                 records.append(rec)
 
-        # Sort for deterministic order
-        records.sort(key=lambda r: (r["perturbation"], r["realization"]))
-        n_realizations = len(records)
-        if n_realizations == 0:
+        if not records:
             raise RuntimeError("TMC manifest is empty; no runs to process")
 
-        # ---- 2. Use first statepoint as reference to determine shape & metadata ----
-        first_sp_path = Path(records[0]["statepoint"]).resolve()
-        tally_names = {}  # key: tally id, value: tally name
-        tally_shapes = {}  # key: tally id, value: nd_shape
-        tally_filters = {}  # key: tally id, value: list of filters
-        tally_axisinfo = {}  # key: tally id, value: axis_info dict
+        # Detect mode: old sequential vs new matrix
+        first_rec = records[0]
+        if "indices" in first_rec:
+            mode = "matrix"
+        elif "perturbation" in first_rec and "realization" in first_rec:
+            mode = "sequential"
+        else:
+            raise RuntimeError("Unrecognized manifest record format")
+
+        # ---- 2. Sort & index logic depending on mode ----
+        if mode == "sequential":
+            # sort by (perturbation, realization)
+            records.sort(key=lambda r: (r["perturbation"], r["realization"]))
+            n_realizations = len(records)
+            extra_shape = (n_realizations,)
+            extra_dims = ("realization",)
+            extra_coords = {"realization": np.arange(n_realizations)}
+
+        else:  # mode == "matrix"
+            # each record: {"indices": [i0, i1, ..., i_{p-1}], "statepoint": ...}
+            # sort lexicographically by indices
+            records.sort(key=lambda r: tuple(r["indices"]))
+
+            # number of perturbations = length of indices
+            p = len(first_rec["indices"])
+
+            # In the matrix TMC driver, you used:
+            #   for idx_tuple in itertools.product(range(self.realizations), repeat=p):
+            # so each perturbation dimension has length self.realizations
+            r = int(self.realizations)
+            extra_shape = tuple(r for _ in range(p))  # (r, r, ..., r)
+            extra_dims = tuple(f"perturbation_{i}" for i in range(p))
+            extra_coords = {dim: np.arange(r) for dim in extra_dims}
+
+            n_combos = len(records)
+            expected_combos = r ** p
+            if n_combos != expected_combos:
+                raise RuntimeError(
+                    f"Matrix TMC manifest has {n_combos} runs, but expected {expected_combos} "
+                    f"for realizations={r}, perturbations={p}."
+                )
+
+        # ---- 3. Use first statepoint as reference for tallies ----
+        first_sp_path = resolve_statepoint_path(first_rec["statepoint"])
+        tally_names = {}    # tid -> name
+        tally_shapes = {}   # tid -> nd_shape (filters..., nuclide, score)
+        tally_filters = {}  # tid -> list of filters
+        tally_axisinfo = {} # tid -> axis_info dict
 
         with openmc.StatePoint(str(first_sp_path)) as sp0:
             for tally in sp0.tallies.values():
@@ -143,122 +202,133 @@ class TMCManager:
                 assert flat_shape[1] == n_nuclides
                 assert flat_shape[2] == n_scores
 
-                tally_names[tid]  = tally.name
-                tally_shapes[tid]  = nd_shape
+                tally_names[tid] = tally.name
+                tally_shapes[tid] = nd_shape
                 tally_filters[tid] = filters
 
                 axis_info = {
-                    "sample_axis": 0,
                     "filter_axes": [
                         {"name": type(f).__name__, "num_bins": f.num_bins}
                         for f in filters
                     ],
-                    "nuclide_axis": len(filter_bins) + 1,
-                    "score_axis":   len(filter_bins) + 2,
-                    "nuclides":     [str(n) for n in tally.nuclides] if tally.nuclides else ["total"],
-                    "scores":       list(tally.scores),
+                    "nuclides": [str(n) for n in tally.nuclides] if tally.nuclides else ["total"],
+                    "scores": list(tally.scores),
                 }
 
                 tally_axisinfo[tid] = axis_info
 
-        # ---- 3. Allocate TMC arrays, one per tally ----
-        tmc_data = {}  # key: tally id, value: ndarray (n_samples, ...)
-        tmc_mc_std = {}  # key: tally id, value: MC std_dev per realization
+        # ---- 4. Allocate arrays: one per tally ----
+        tmc_data = {}    # tid -> ndarray (extra_shape + nd_shape)
+        tmc_mc_std = {}  # tid -> ndarray (extra_shape + nd_shape)
 
         for tid, nd_shape in tally_shapes.items():
-            tmc_data[tid] = np.empty((n_realizations,) + nd_shape, dtype=float)
-            tmc_mc_std[tid] = np.empty((n_realizations,) + nd_shape, dtype=float)
+            full_shape = extra_shape + nd_shape
+            tmc_data[tid] = np.empty(full_shape, dtype=float)
+            tmc_mc_std[tid] = np.empty(full_shape, dtype=float)
 
-        # ---- 4. Fill arrays by looping over all statepoints ----
-        for i, rec in enumerate(records):
-            sp_path = Path(rec["statepoint"]).resolve()
-            with openmc.StatePoint(str(sp_path)) as sp:
-                for tid, arr in tmc_data.items():
-                    # assumes same tally IDs exist in every statepoint
-                    tally = sp.tallies[tid]
-                    mean_flat = tally.mean
-                    std_flat = tally.std_dev
-                    nd_shape = tally_shapes[tid]
-                    mean_nd = mean_flat.reshape(nd_shape)
-                    std_nd = std_flat.reshape(nd_shape)
-                    arr[i, ...] = mean_nd
-                    tmc_mc_std[tid][i, ...] = std_nd
+        # ---- 5. Fill arrays by looping over statepoints ----
+        if mode == "sequential":
+            for i, rec in enumerate(records):
+                sp_path = resolve_statepoint_path(rec["statepoint"])
+                with openmc.StatePoint(str(sp_path)) as sp:
+                    for tid in tmc_data.keys():
+                        tally = sp.tallies[tid]
+                        mean_flat = tally.mean
+                        std_flat = tally.std_dev
+                        nd_shape = tally_shapes[tid]
+                        mean_nd = mean_flat.reshape(nd_shape)
+                        std_nd = std_flat.reshape(nd_shape)
+                        tmc_data[tid][i, ...] = mean_nd
+                        tmc_mc_std[tid][i, ...] = std_nd
 
-        # ---- 5. Build xarray Dataset and write to disk ----
+        else:  # mode == "matrix"
+            # Fill as flat (n_combos, ...) then reshape first axis into extra_shape
+            n_combos = len(records)
+            flat_data = {}
+            flat_mc_std = {}
+            for tid, nd_shape in tally_shapes.items():
+                flat_shape = (n_combos,) + nd_shape
+                flat_data[tid] = np.empty(flat_shape, dtype=float)
+                flat_mc_std[tid] = np.empty(flat_shape, dtype=float)
+
+            for i, rec in enumerate(records):
+                sp_path = resolve_statepoint_path(rec["statepoint"])
+                with openmc.StatePoint(str(sp_path)) as sp:
+                    for tid in flat_data.keys():
+                        tally = sp.tallies[tid]
+                        mean_flat = tally.mean
+                        std_flat = tally.std_dev
+                        nd_shape = tally_shapes[tid]
+                        mean_nd = mean_flat.reshape(nd_shape)
+                        std_nd = std_flat.reshape(nd_shape)
+                        flat_data[tid][i, ...] = mean_nd
+                        flat_mc_std[tid][i, ...] = std_nd
+
+            # reshape into extra_shape + nd_shape
+            for tid, arr in flat_data.items():
+                arr.shape = extra_shape + tally_shapes[tid]
+                tmc_data[tid][...] = arr
+            for tid, arr in flat_mc_std.items():
+                arr.shape = extra_shape + tally_shapes[tid]
+                tmc_mc_std[tid][...] = arr
+
+        # ---- 6. Build xarray Dataset and write ----
         ds = xr.Dataset()
-        sample_coord = np.arange(n_realizations)
 
         for tid, arr in tmc_data.items():
             nd_shape = tally_shapes[tid]
             filters = tally_filters[tid]
-            
-            # Build dimension names following OpenMC conventions
-            # Make nuclide and score dimensions unique per tally to avoid conflicts
+
+            # Filter dims based on filter types
             filter_dims = []
             for f in filters:
-                # Use filter type name without "Filter" suffix, lowercase
                 filter_type = type(f).__name__.replace("Filter", "").lower()
                 filter_dims.append(filter_type)
-            
-            dims = ("realization",) + tuple(filter_dims) + (f"nuclide_{tid}", f"score_{tid}")
 
-            # Use tally name if available, otherwise fall back to ID
+            nuclide_dim = f"nuclide_{tid}"
+            score_dim = f"score_{tid}"
+
+            dims = extra_dims + tuple(filter_dims) + (nuclide_dim, score_dim)
+
+            coords = dict(extra_coords)
+
             tally_name = tally_names[tid] or f"tally_{tid}"
-            
+
             da = xr.DataArray(
                 arr,
                 dims=dims,
-                coords={"realization": sample_coord},
+                coords=coords,
                 name=tally_name,
             )
-            
-            # Create corresponding MC std_dev DataArray
+
             da_mc_std = xr.DataArray(
                 tmc_mc_std[tid],
                 dims=dims,
-                coords={"realization": sample_coord},
+                coords=coords,
                 name=f"{tally_name}_mc_std",
             )
 
-            # Attach tally metadata
             da.attrs["tally_id"] = tid
             da.attrs["tally_name"] = tally_names[tid]
             da_mc_std.attrs["tally_id"] = tid
             da_mc_std.attrs["tally_name"] = tally_names[tid]
 
-            # Attach axis info as attrs; serialize non-scalar things to JSON strings
             axisinfo = tally_axisinfo[tid]
-            for k, v in axisinfo.items():
-                # scalars are fine
-                if isinstance(v, (int, float, bool, str, np.number)):
-                    da.attrs[k] = v
-                else:
-                    # lists, dicts, numpy arrays -> JSON string
-                    if isinstance(v, np.ndarray):
-                        to_dump = v.tolist()
+            for target_da in (da, da_mc_std):
+                for k, v in axisinfo.items():
+                    if isinstance(v, (int, float, bool, str, np.number)):
+                        target_da.attrs[k] = v
                     else:
-                        to_dump = v
-                    da.attrs[k] = json.dumps(to_dump)
-            
-            # Copy axis info to MC std DataArray
-            for k, v in axisinfo.items():
-                if isinstance(v, (int, float, bool, str, np.number)):
-                    da_mc_std.attrs[k] = v
-                else:
-                    if isinstance(v, np.ndarray):
-                        to_dump = v.tolist()
-                    else:
-                        to_dump = v
-                    da_mc_std.attrs[k] = json.dumps(to_dump)
+                        if isinstance(v, np.ndarray):
+                            to_dump = v.tolist()
+                        else:
+                            to_dump = v
+                        target_da.attrs[k] = json.dumps(to_dump)
 
             ds[da.name] = da
             ds[da_mc_std.name] = da_mc_std
 
-        # If you have netcdf4/h5netcdf installed, you can also specify engine explicitly:
-        # ds.to_netcdf(tmc_statepoint, engine="h5netcdf")
         ds.to_netcdf(tmc_statepoint)
-        
-        # Store path for later retrieval
         self.tmc_statepoint_path = tmc_statepoint
 
     def get_tmc_statepoint(self, path=None):

--- a/src/openmc_fusion_benchmarks/uq/tmc_manager.py
+++ b/src/openmc_fusion_benchmarks/uq/tmc_manager.py
@@ -199,10 +199,25 @@ class TMCManager:
         if mode == "sequential":
             # sort by (perturbation, realization)
             records.sort(key=lambda r: (r["perturbation"], r["realization"]))
-            n_realizations = len(records)
-            extra_shape = (n_realizations,)
-            extra_dims = ("realization",)
-            extra_coords = {"realization": np.arange(n_realizations)}
+            
+            # Infer number of perturbations and realizations
+            n_perturbations = max(r["perturbation"] for r in records) + 1
+            n_realizations = max(r["realization"] for r in records) + 1
+            
+            # Verify we have complete data
+            expected_total = n_perturbations * n_realizations
+            if len(records) != expected_total:
+                raise RuntimeError(
+                    f"Sequential TMC manifest has {len(records)} runs, but inferred "
+                    f"{n_perturbations} perturbations × {n_realizations} realizations = {expected_total}"
+                )
+            
+            extra_shape = (n_perturbations, n_realizations)
+            extra_dims = ("perturbation", "realization")
+            extra_coords = {
+                "perturbation": np.arange(n_perturbations),
+                "realization": np.arange(n_realizations)
+            }
 
         elif mode == "diagonal":
             # Diagonal matrix mode: indices are present but we treat them as a 1D TMC dim
@@ -286,8 +301,25 @@ class TMCManager:
             tmc_mc_std[tid] = np.empty(full_shape, dtype=float)
 
         # ---- 5. Fill arrays by looping over statepoints ----
-        if mode in ("sequential", "diagonal"):
-            # same shape logic: one 1D TMC dim called "realization"
+        if mode == "sequential":
+            # 2D structure: (perturbation, realization)
+            for rec in records:
+                sp_path = resolve_statepoint_path(rec["statepoint"])
+                with openmc.StatePoint(str(sp_path)) as sp:
+                    for tid in tmc_data.keys():
+                        tally = sp.tallies[tid]
+                        mean_flat = tally.mean
+                        std_flat = tally.std_dev
+                        nd_shape = tally_shapes[tid]
+                        mean_nd = mean_flat.reshape(nd_shape)
+                        std_nd = std_flat.reshape(nd_shape)
+                        p_idx = rec["perturbation"]
+                        r_idx = rec["realization"]
+                        tmc_data[tid][p_idx, r_idx, ...] = mean_nd
+                        tmc_mc_std[tid][p_idx, r_idx, ...] = std_nd
+
+        elif mode == "diagonal":
+            # 1D structure: one "realization" dim
             for i, rec in enumerate(records):
                 sp_path = resolve_statepoint_path(rec["statepoint"])
                 with openmc.StatePoint(str(sp_path)) as sp:
@@ -350,6 +382,10 @@ class TMCManager:
 
             # coords: TMC dims
             coords = dict(extra_coords)
+
+            # coords: filter dimensions (add integer indices for each filter)
+            for i, (f, fdim) in enumerate(zip(filters, filter_dims)):
+                coords[fdim] = (fdim, np.arange(f.num_bins))
 
             # coords: nuclide / score for this tally
             nuclides = axisinfo["nuclides"]
@@ -554,10 +590,10 @@ class TMCTally:
         self._da_mc_std = mc_std_da
         self._parent_ds = parent_ds
 
-        # Identify TMC dimensions: "realization" for sequential, "perturbation_*" for matrix
+        # Identify TMC dimensions: "perturbation" and "realization" for sequential, "perturbation_*" for matrix
         self._tmc_dims = [
             d for d in self._da.dims
-            if d == "realization" or d.startswith("perturbation_")
+            if d in ("perturbation", "realization") or d.startswith("perturbation_")
         ]
 
     @property
@@ -678,108 +714,95 @@ class TMCTally:
         """
         if self._da_mc_std is not None:
             return self._da_mc_std.values
-
-        # Fallback to zeros if not available
         return np.zeros_like(self._da.values)
+
+    @property
+    def per_perturbation_mean(self):
+        """
+        Mean value for each perturbation type (averaging over all realizations).
+        
+        For sequential mode: shape (n_perturbations, filters..., nuclide, score)
+          - Averages over realizations, keeping separate perturbation results
+        
+        For matrix mode: shape (n_perturbations, filters..., nuclide, score)
+          - Averages over all perturbation_i dimensions (all realization grids)
+          - Returns one value per perturbation type
+        
+        For diagonal mode: returns overall mean (single realization dimension)
+        """
+        dims = tuple(self._da.dims)
+        has_pert = "perturbation" in dims
+        has_real = "realization" in dims
+        
+        if has_pert and has_real:
+            # Sequential mode: average over realizations only
+            result = self._da.mean(dim="realization")
+            return result.values
+        elif has_pert:
+            # Edge case: perturbation dim exists but no realization dim
+            return self._da.values
+        else:
+            # Matrix mode: average over all perturbation_i dimensions
+            pert_dims = [d for d in self._tmc_dims if d.startswith("perturbation_")]
+            if pert_dims:
+                # Average over all perturbation dimensions (all realization grids)
+                result = self._da.mean(dim=pert_dims)
+                # Result shape: (filters..., nuclide, score)
+                # Expand to add perturbation axis: (n_perturbations, filters..., nuclide, score)
+                n_perturbations = len(pert_dims)
+                # Repeat the result for each perturbation
+                result_expanded = np.tile(result.values, (n_perturbations,) + (1,) * (result.ndim))
+                return result_expanded
+            else:
+                # Diagonal or other: collapse all TMC dims
+                return self.mean
+    @property
+    def per_perturbation_std_dev(self):
+        """
+        Standard deviation for each perturbation type (across all realizations).
+        
+        For sequential mode: shape (n_perturbations, filters..., nuclide, score)
+          - Std deviation across realizations, keeping separate perturbation results
+        
+        For matrix mode: shape (n_perturbations, filters..., nuclide, score)
+          - Std deviation over all perturbation_i dimensions (all realization grids)
+          - Returns one value per perturbation type
+        
+        For diagonal mode: returns overall std_dev (single realization dimension)
+        """
+        dims = tuple(self._da.dims)
+        has_pert = "perturbation" in dims
+        has_real = "realization" in dims
+        
+        if has_pert and has_real:
+            # Sequential mode: std over realizations only
+            result = self._da.std(dim="realization")
+            return result.values
+        elif has_pert:
+            # Edge case: perturbation dim exists but no realization dim
+            return np.zeros_like(self._da.values)
+        else:
+            # Matrix mode: std over all perturbation_i dimensions
+            pert_dims = [d for d in self._tmc_dims if d.startswith("perturbation_")]
+            if pert_dims:
+                # Std over all perturbation dimensions (all realization grids)
+                result = self._da.std(dim=pert_dims)
+                # Result shape: (filters..., nuclide, score)
+                # Expand to add perturbation axis: (n_perturbations, filters..., nuclide, score)
+                n_perturbations = len(pert_dims)
+                # Repeat the result for each perturbation
+                result_expanded = np.tile(result.values, (n_perturbations,) + (1,) * (result.ndim))
+                return result_expanded
+            else:
+                # Diagonal or other: collapse all TMC dims
+                return self.std_dev
+
     
     @property
     def perturbation_dims(self):
         """Names of perturbation dimensions in matrix mode (e.g. 'perturbation_0', ...)."""
         return tuple(d for d in self._tmc_dims if d.startswith("perturbation_"))
     
-    @property
-    def per_perturbation_mean(self, perturbation_dim=None, as_xarray=False):
-        """
-        Mean per perturbation dimension, marginalised over other perturbation dims.
-
-        In matrix mode:
-          - If perturbation_dim is None: returns a dict {dim_name: np.ndarray}
-            where each array has dims (that dim, physical dims...).
-          - If perturbation_dim is given (e.g. 'perturbation_0'):
-            returns just that array.
-
-        In sequential mode (only 'realization' TMC dim):
-          - Equivalent to t.mean (no separate per-perturbation concept).
-
-        Parameters
-        ----------
-        perturbation_dim : str, optional
-            Name of a specific perturbation dimension to extract.
-        as_xarray : bool, optional
-            If True, return xarray.DataArray(s) instead of plain numpy arrays.
-
-        Returns
-        -------
-        dict[str, np.ndarray] or np.ndarray or xarray.DataArray
-        """
-        pert_dims = self.perturbation_dims
-        if not pert_dims:
-            # sequential mode: only 'realization'
-            if perturbation_dim is not None:
-                raise ValueError("No perturbation_* dims in this tally (likely sequential mode).")
-            return self.mean if not as_xarray else self._da.mean(dim=self._tmc_dims)
-
-        # helper: compute for one dim
-        def _one_dim(dim):
-            other_pert_dims = [d for d in pert_dims if d != dim]
-            if other_pert_dims:
-                da_red = self._da.mean(dim=other_pert_dims)
-            else:
-                da_red = self._da
-            return da_red if as_xarray else da_red.values
-
-        if perturbation_dim is not None:
-            if perturbation_dim not in pert_dims:
-                raise ValueError(f"{perturbation_dim!r} is not a perturbation dimension in {pert_dims}")
-            return _one_dim(perturbation_dim)
-
-        # all perturbation dims
-        return {dim: _one_dim(dim) for dim in pert_dims}
-    
-    @property
-    def per_perturbation_std_dev(self, perturbation_dim=None, as_xarray=False):
-        """
-        Std dev per perturbation dimension, marginalised over other perturbation dims.
-
-        In matrix mode:
-          - If perturbation_dim is None: returns a dict {dim_name: np.ndarray}
-          - If perturbation_dim is given: returns just that array.
-
-        In sequential mode:
-          - Equivalent to t.std_dev.
-
-        Parameters
-        ----------
-        perturbation_dim : str, optional
-            Name of a specific perturbation dimension to extract.
-        as_xarray : bool, optional
-            If True, return xarray.DataArray(s) instead of plain numpy arrays.
-
-        Returns
-        -------
-        dict[str, np.ndarray] or np.ndarray or xarray.DataArray
-        """
-        pert_dims = self.perturbation_dims
-        if not pert_dims:
-            if perturbation_dim is not None:
-                raise ValueError("No perturbation_* dims in this tally (likely sequential mode).")
-            return self.std_dev if not as_xarray else self._da.std(dim=self._tmc_dims)
-
-        def _one_dim(dim):
-            other_pert_dims = [d for d in pert_dims if d != dim]
-            if other_pert_dims:
-                da_red = self._da.std(dim=other_pert_dims)
-            else:
-                da_red = self._da * 0.0  # only one TMC point along that dim; std=0
-            return da_red if as_xarray else da_red.values
-
-        if perturbation_dim is not None:
-            if perturbation_dim not in pert_dims:
-                raise ValueError(f"{perturbation_dim!r} is not a perturbation dimension in {pert_dims}")
-            return _one_dim(perturbation_dim)
-
-        return {dim: _one_dim(dim) for dim in pert_dims}
-
     def get_slice(self, scores=None, nuclides=None, **filter_kwargs):
         """
         Get a slice of the TMC data with optional filtering.


### PR DESCRIPTION
This PR is a follow up of #79, Introducing different _modes_ for running the TMC uncertainty quantification.  

# TMC Modes
Modes available are __sequential__, __matrix__ and __diagonal__.

 __sequential__ is the one already available implemented with #79. namely, performs one perturbation at a time (with all its realizations), for a total of perturbations-times-realizations (__r*p__) models/simulations/tmc-iterations. Useful for identifying the effect of every single perturbation type to the total uncertainty.

__matrix__ mode  builds a matrix of _perturbations_ and _realizations_. So, for every new realization of a single perturbation, the `TMCManager` runs all the realizations of all the other perturbations. Such matrix of perturbations-realizations would hence have as many dimensions as the number of perturbations (__p__) and every dimension is as long as the number of realizations (__r__), ending up with a total number of models/simulations/tmc-iterations as __r^p__. Useful to cover the whole perturbation-realization "phase-space", but often computationally and memory prohibitive.

__diagonal__ mode takes the matrix of the _matrix_ mode and runs only the models on the diagonal. On the diagonal all the perturbations get a new realization (hence a new value of the perturbed parameter) simultaneously achieving, arguably, a faster convergence to the total uncertainty. Useful to get faster to total uncertainty with a TMC method.

# Usage
The usage is similar, the user just needs to specify the mode to run with the `TMCManager.run` method:

```python
# Instantiate tmc manager
tmc_manager = ofb.uq.TMCManager(base_model=model, perturbations=[perturb_water_density], realizations=100, rng=np.random.default_rng(42))
# Run tmc
tmc_manager.run(mode="diagonal") 
```
 